### PR TITLE
ci(release): fix trusted npm publish via tag push

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -34,7 +34,6 @@ jobs:
     name: Publish to npm
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    environment: npm-publish
 
     steps:
       - name: Checkout

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -4,22 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-  workflow_dispatch:
-    inputs:
-      npm_tag:
-        description: 'Override npm dist-tag (beta, rc, latest). Leave empty for auto.'
-        required: false
-        type: choice
-        options:
-          - ''
-          - beta
-          - rc
-          - latest
-      skip_version_tag_check:
-        description: 'Skip vX.Y.Z tag to package.json version check'
-        required: false
-        default: false
-        type: boolean
 
 concurrency:
   group: publish-${{ github.ref }}
@@ -42,9 +26,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: npm
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+          cache: npm
 
       - name: Install dependencies
         run: npm ci
@@ -74,21 +58,11 @@ jobs:
             AUTO_TAG="latest"
           fi
 
-          INPUT_TAG="${{ github.event.inputs.npm_tag }}"
-          if [[ -n "${INPUT_TAG:-}" ]]; then
-            TAG="$INPUT_TAG"
-          else
-            TAG="$AUTO_TAG"
-          fi
-
-          if [[ "${{ github.event_name }}" == "push" ]]; then
-            GIT_TAG="${GITHUB_REF#refs/tags/}"
-            if [[ "${{ github.event.inputs.skip_version_tag_check || 'false' }}" != "true" ]]; then
-              if [[ "$GIT_TAG" != "v$VERSION" ]]; then
-                echo "Tag/version mismatch: git tag=$GIT_TAG package.json=$VERSION"
-                exit 1
-              fi
-            fi
+          TAG="$AUTO_TAG"
+          GIT_TAG="${GITHUB_REF#refs/tags/}"
+          if [[ "$GIT_TAG" != "v$VERSION" ]]; then
+            echo "Tag/version mismatch: git tag=$GIT_TAG package.json=$VERSION"
+            exit 1
           fi
 
           echo "name=$NAME" >> "$GITHUB_OUTPUT"
@@ -104,8 +78,18 @@ jobs:
             exit 1
           fi
 
+      - name: Publish diagnostics
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "workflow_ref=$GITHUB_WORKFLOW_REF"
+          echo "workflow=$GITHUB_WORKFLOW"
+          echo "ref=$GITHUB_REF"
+          node -v
+          npm -v
+
       - name: Publish package
-        run: npm publish --tag "${{ steps.meta.outputs.tag }}" --provenance
+        run: npm publish --tag "${{ steps.meta.outputs.tag }}" --access public --provenance
 
       - name: Summary
         run: |


### PR DESCRIPTION
## Why\nTrusted publish was intermittently failing with E404/identity mismatch patterns.\n\n## Changes\n- release workflow now publishes only on tag push ()\n- upgraded publish runner to Node 24\n- explicit npm registry setup in setup-node\n- simplified metadata/tag checks for tag-driven releases\n- added publish diagnostics (workflow/ref/node/npm versions)\n- 
> homebridge-plugin-klares4@2.0.1 prepublishOnly
> npm run build


> homebridge-plugin-klares4@2.0.1 build
> tsc uses \n\n## Expected\nReliable npm trusted-publisher releases on tag push without manual token auth.