### PR TITLE
feat: Homebridge 2.0 + Matter stable (v2.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-05-19
+
+Stable release of the Homebridge 2.0 + Matter compatibility track. Aggregates
+the work shipped over the `2.1.0-rc.0` … `2.1.0-rc.12` cycle, verified on a
+production Matter-only child bridge (`hap=false`) with 81 Lares4 accessories
+in Apple Home.
+
+Highlights vs `2.0.1`:
+
+- Homebridge 2.0 support with native Matter accessory registration via
+  `api.matter.registerPlatformAccessories` (Thermostat, OnOffLight,
+  DimmableLight, WindowCovering, TemperatureSensor, HumiditySensor,
+  LightSensor, MotionSensor, ContactSensor, OnOffSwitch).
+- Probe-based register settle: state updates are only pushed once
+  `getAccessoryState` confirms the Matter endpoint is queryable.
+- Cache-resume path: accessories already in the Homebridge cache are
+  resumed without re-registering, so controllers (Apple Home, Google
+  Home) no longer see `parts list change` notifications at every
+  restart.
+- Persistent thermostat fallback set (`klares4-matter-fallback.json`):
+  thermostats that fall back to `TemperatureSensor` stay in sync with
+  the Matter storage across restarts.
+- Scenarios and gates are momentary `OnOffSwitch` devices with
+  configurable auto-off (`scenarioAutoOffDelay`, default 500ms).
+- Thermostat presetTypes workaround: `presetTypeFeatures` is now passed
+  as a bitmap object, so matter.js 0.17 accepts the `Thermostat`
+  cluster and thermostats register as full Thermostat devices in
+  Apple Home (setpoint + mode control restored).
+
 ## [2.1.0-rc.12] - 2026-05-19
 
 ### Fixed (Matter)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0-rc.12] - 2026-05-19
+
+### Fixed (Matter)
+
+- Thermostat registration: `presetTypeFeatures` now passed as a bitmap object `{ automatic: false, supportsNames: false }` instead of the number `0`, which matter.js 0.17 rejected with `Cannot manage number because it is not a bitmap object`. Thermostats now register as proper Matter `Thermostat` devices (not as `TemperatureSensor` fallback), restoring setpoint and mode control from Apple Home.
+- Register/update race condition: replaced the fixed 2-second settle timer with a probe-based loop (`getAccessoryState` with exponential backoff, configurable via `KLARES4_MATTER_REGISTER_TIMEOUT_MS` / `KLARES4_MATTER_REGISTER_POLL_MS` / `KLARES4_MATTER_REGISTER_POLL_MAX_MS`). State updates are no longer pushed before the Matter endpoint is actually ready, eliminating `MatterDeviceError: Accessory ... not registered or missing endpoint` at startup.
+- Scenarios stuck in `ON` state: scenarios now expose `OnOffSwitch` and auto-reset to off after a configurable delay (`scenarioAutoOffDelay`, default 500ms) so subsequent triggers work as expected.
+- Gate handler asymmetry: gates now use `OnOffSwitch` with momentary semantics (single impulse + auto-off) instead of `OnOffOutlet` with dual toggle.
+- Full re-registration on every restart: accessories already present in the Homebridge cache are now resumed via probe instead of re-registered, preventing controllers (Apple Home, Google Home) from seeing 81 spurious `parts list change` notifications.
+- Fallback persistence: thermostats that fall back to `TemperatureSensor` are persisted to `klares4-matter-fallback.json` so the plugin and the Matter storage stay in sync across restarts (no more cluster mismatch between an endpoint stored as `TemperatureSensor` and the plugin still pushing to the `thermostat` cluster).
+- 30-second state-update bootstrap delay reduced to 0 by default (env override still available); combined with probe-based settle, system temperature sensors now appear in Apple Home within seconds of startup.
+
 ## [2.0.1] - 2026-03-13
 
 ### Added

--- a/MATTER_MIGRATION.md
+++ b/MATTER_MIGRATION.md
@@ -1,0 +1,286 @@
+# Piano di Migrazione: Homebridge 2.0 & Matter — `homebridge-plugin-klares4`
+
+## Contesto
+
+Homebridge 2.0 introduce un layer Matter che valida gli accessori **immediatamente all'avvio**, prima che WebSocket/MQTT verso la centrale Ksenia Lares4 si connetta. Nel codice attuale:
+
+- [src/platform/accessory-registry.ts:30-33](Sviluppo/homebridge-plugin-klares4/src/platform/accessory-registry.ts#L30-L33) — `configureAccessory` salva l'accessorio in mappa ma **non istanzia l'handler**. L'handler viene creato solo dentro `addAccessory`, che gira al primo ciclo di discovery (dopo connessione WS).
+- Risultato in HB 1.x: tollerato — HomeKit attende.
+- Risultato in HB 2.0 + Matter: il bridge Matter ispeziona l'accessorio prima che `addAccessory` sia stato chiamato, non trova `onGet/onSet` registrati e **scarta silenziosamente** l'accessorio dalla rete Matter.
+
+Inoltre alcuni `onGet` (es. `ThermostatAccessory.getCurrentTemperature` a [src/accessories/thermostat-accessory.ts:115](Sviluppo/homebridge-plugin-klares4/src/accessories/thermostat-accessory.ts#L115)) restituiscono `0` come fallback, valore che è valido per `CurrentTemperature` (-270..100) ma sarebbe fuori bounds se applicato a `TargetTemperature` (impostata 10..38 a [riga 72-76](Sviluppo/homebridge-plugin-klares4/src/accessories/thermostat-accessory.ts#L72-L76)).
+
+Obiettivo: rendere il plugin **100% compatibile Matter** mantenendo retro-compatibilità con HB 1.x, senza introdurre dipendenze Matter dirette (Homebridge espone gli accessori a Matter automaticamente).
+
+---
+
+## Stato Attuale Validato
+
+| Area | Stato | Note |
+|---|---|---|
+| `engines.homebridge` | `^1.6.0 \|\| ^2.0.0-beta.0` | Già aperto a 2.0 |
+| `devDependencies.homebridge` | `^1.11.1` | Va aggiornato per test contro 2.0 |
+| `@types/node` | `^20.0.0` | OK per Node 20; salire a `^22` opzionale |
+| `createAccessoryHandler` callback | ✅ presente in [accessory-registry.ts:13-16](Sviluppo/homebridge-plugin-klares4/src/platform/accessory-registry.ts#L13-L16) | Pronto per essere chiamato da `configureAccessory` |
+| `accessory.context.device` su cache | ✅ persistito a [riga 42, 57, 81](Sviluppo/homebridge-plugin-klares4/src/platform/accessory-registry.ts#L42) | Disponibile in `configureAccessory` al restore |
+| `HapStatusError` su errori `onSet` | ✅ già conforme | Tutti gli accessori (light, cover, thermostat, gate, scenario) |
+| `AccessoryInformation` (Manufacturer/Model/Serial/Firmware) | ✅ impostati in ogni costruttore | `SerialNumber = device.id` senza validazione vuoto |
+| `getCurrentTemperature` fallback | ⚠️ ritorna `0` se undefined | Accettabile per HAP, ma loggare e usare ultimo noto è più Matter-friendly |
+| `FirmwareRevision` | ⚠️ hardcoded `'2.0.1-beta0'` | Va allineato a `package.json.version` |
+| Child Bridge | Non configurato | Raccomandato (non obbligatorio) per Matter |
+
+---
+
+## Modifiche da Applicare
+
+### 1. `package.json` — dipendenze di sviluppo
+
+[package.json](Sviluppo/homebridge-plugin-klares4/package.json)
+
+- `engines.homebridge`: lasciare `"^1.6.0 || ^2.0.0-beta.0"` (già corretto). Quando HB 2.0 stable esce, stringere a `"^1.8.0 || ^2.0.0"`.
+- `devDependencies.homebridge`: aggiornare a `"^2.0.0-beta.0"` per type-check contro le API 2.0.
+- `devDependencies.@types/node`: aggiornare a `"^22.0.0"` (allineato a Node 20 LTS + 22).
+- Nessuna nuova `dependencies` runtime necessaria — Homebridge gestisce Matter internamente.
+
+### 2. `src/platform/accessory-registry.ts` — istanziare handler dalla cache
+
+[src/platform/accessory-registry.ts:30-33](Sviluppo/homebridge-plugin-klares4/src/platform/accessory-registry.ts#L30-L33)
+
+Modificare `configureAccessory` per istanziare immediatamente l'handler dal `context.device` cached, **prima** che il discovery WS produca dati freschi. Aggiungere check di validità:
+
+```typescript
+public configureAccessory(accessory: PlatformAccessory): void {
+    this.options.log.info('Loading accessory from cache:', accessory.displayName);
+    this.options.accessories.set(accessory.UUID, accessory);
+
+    // Matter-readiness: handler must be live before the bridge inspects the accessory.
+    const device = accessory.context?.device as KseniaDevice | undefined;
+    if (!device || !device.id) {
+        this.options.log.warn(
+            `Skipping cache handler init for ${accessory.displayName}: missing device context`,
+        );
+        return;
+    }
+
+    const handler = this.options.createAccessoryHandler(accessory, device);
+    if (handler) {
+        this.options.accessoryHandlers.set(accessory.UUID, handler);
+        this.options.log.debug(`Handler attached from cache for ${device.name}`);
+    }
+}
+```
+
+E in `addAccessory` (riga 40-52) il ramo "exising accessory + no handler" diventa raro ma resta come safety-net (nessuna modifica).
+
+### 3. Validazione di `device.id` non-vuoto (SerialNumber)
+
+In ciascun costruttore di accessorio (light, cover, gate, sensor, zone, thermostat, scenario), prima di impostare `SerialNumber`, garantire fallback non-vuoto:
+
+```typescript
+const serial = this.device.id && this.device.id.length > 0
+    ? this.device.id
+    : `lares4-${accessory.UUID.slice(0, 8)}`;
+accessoryInfoService.setCharacteristic(
+    this.platform.Characteristic.SerialNumber,
+    serial,
+);
+```
+
+File interessati:
+- [src/accessories/light-accessory.ts:26](Sviluppo/homebridge-plugin-klares4/src/accessories/light-accessory.ts#L26)
+- [src/accessories/cover-accessory.ts](Sviluppo/homebridge-plugin-klares4/src/accessories/cover-accessory.ts)
+- [src/accessories/gate-accessory.ts](Sviluppo/homebridge-plugin-klares4/src/accessories/gate-accessory.ts)
+- [src/accessories/sensor-accessory.ts](Sviluppo/homebridge-plugin-klares4/src/accessories/sensor-accessory.ts)
+- [src/accessories/zone-accessory.ts](Sviluppo/homebridge-plugin-klares4/src/accessories/zone-accessory.ts)
+- [src/accessories/thermostat-accessory.ts:33](Sviluppo/homebridge-plugin-klares4/src/accessories/thermostat-accessory.ts#L33)
+- [src/accessories/scenario-accessory.ts](Sviluppo/homebridge-plugin-klares4/src/accessories/scenario-accessory.ts)
+
+### 4. `FirmwareRevision` allineato automaticamente a `package.json.version`
+
+Obiettivo: ogni bump di versione (manuale, `npm version`, o release CI) aggiorna **da solo** la `FirmwareRevision` esposta a HomeKit/Matter, **senza** modifiche al codice TypeScript.
+
+#### 4.1 Creare modulo `src/plugin-version.ts` (NUOVO)
+
+```typescript
+// src/plugin-version.ts
+// Auto-sync con package.json — non modificare manualmente la stringa.
+import { version as RAW_VERSION } from '../package.json';
+
+/**
+ * FirmwareRevision conforme HAP/Matter: solo MAJOR.MINOR.PATCH.
+ * Matter rifiuta suffissi tipo `-beta0`, `-rc1`, `+build`.
+ * Es: "2.1.0-beta0" → "2.1.0", "2.1.0" → "2.1.0".
+ */
+export const PLUGIN_VERSION: string = RAW_VERSION.split(/[-+]/)[0];
+
+/** Versione raw (con eventuali suffissi) per logging. */
+export const PLUGIN_VERSION_RAW: string = RAW_VERSION;
+```
+
+#### 4.2 `tsconfig.json` — abilitare import JSON
+
+Verificare/aggiungere:
+```jsonc
+{
+  "compilerOptions": {
+    "resolveJsonModule": true,
+    "esModuleInterop": true
+    // ... resto invariato
+  }
+}
+```
+
+#### 4.3 `package.json` — includere il file nel bundle pubblicato
+
+Il campo `files` è già:
+```json
+"files": ["dist", "config.schema.json", "README.md", "CHANGELOG.md", "LICENSE"]
+```
+
+`package.json` **non** è nell'array, ma viene **sempre** incluso da npm automaticamente. Tuttavia con `resolveJsonModule`, TypeScript copia il riferimento dentro `dist/plugin-version.js` come `require("../package.json")` (path relativo da `dist/`). Verificare con:
+
+```bash
+npm run build
+node -e "console.log(require('./dist/plugin-version').PLUGIN_VERSION)"
+# atteso: "2.0.1"
+```
+
+Se il path risolto da `dist/plugin-version.js` punta a `../package.json` (cioè la root del pacchetto pubblicato), funziona out-of-the-box perché `package.json` è sempre presente. **Nessuna modifica al campo `files`**.
+
+#### 4.4 Usare `PLUGIN_VERSION` in tutti gli accessori
+
+Sostituire `'2.0.1-beta0'` hardcoded in 7 file:
+
+```typescript
+import { PLUGIN_VERSION } from '../plugin-version';
+// ...
+accessoryInfoService.setCharacteristic(
+    this.platform.Characteristic.FirmwareRevision,
+    PLUGIN_VERSION,
+);
+```
+
+File: [light-accessory.ts:27](Sviluppo/homebridge-plugin-klares4/src/accessories/light-accessory.ts#L27), [cover-accessory.ts](Sviluppo/homebridge-plugin-klares4/src/accessories/cover-accessory.ts), [gate-accessory.ts](Sviluppo/homebridge-plugin-klares4/src/accessories/gate-accessory.ts), [sensor-accessory.ts](Sviluppo/homebridge-plugin-klares4/src/accessories/sensor-accessory.ts), [zone-accessory.ts](Sviluppo/homebridge-plugin-klares4/src/accessories/zone-accessory.ts), [thermostat-accessory.ts:34](Sviluppo/homebridge-plugin-klares4/src/accessories/thermostat-accessory.ts#L34), [scenario-accessory.ts](Sviluppo/homebridge-plugin-klares4/src/accessories/scenario-accessory.ts).
+
+#### 4.5 Guard di regressione (test)
+
+Aggiungere `test/plugin-version.test.js`:
+
+```javascript
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { PLUGIN_VERSION, PLUGIN_VERSION_RAW } = require('../dist/plugin-version');
+const pkg = require('../package.json');
+
+test('PLUGIN_VERSION_RAW matches package.json version exactly', () => {
+    assert.strictEqual(PLUGIN_VERSION_RAW, pkg.version);
+});
+
+test('PLUGIN_VERSION is HAP/Matter-compliant semver (M.m.p, no suffix)', () => {
+    assert.match(PLUGIN_VERSION, /^\d+\.\d+\.\d+$/);
+});
+```
+
+Così se qualcuno bumpa `package.json` a una forma non-semver-strict, il test fallisce in CI.
+
+#### 4.6 Effetto
+
+| Scenario | Prima | Dopo |
+|---|---|---|
+| `npm version patch` → `2.0.2` | resta `2.0.1-beta0` (bug) | diventa `2.0.2` automaticamente |
+| `npm version prerelease` → `2.1.0-beta0` | resta `2.0.1-beta0` | diventa `2.1.0` (suffisso strippato) |
+| Pubblicazione su npm | FW disallineato a versione pacchetto | FW sempre allineato |
+
+### 5. `ThermostatAccessory` — bounds e stato iniziale Matter-safe
+
+[src/accessories/thermostat-accessory.ts](Sviluppo/homebridge-plugin-klares4/src/accessories/thermostat-accessory.ts)
+
+- **`getCurrentTemperature`** (riga 108-117): ritornare l'ultimo valore noto memorizzato in `accessory.context` invece di `0`. `0` è formalmente nei bounds (-270..100) ma confonde Matter e l'app Casa mostra "0°C" all'avvio. Soluzione: persistere `lastKnownTemp` in `accessory.context` e usarlo come fallback; default finale `21`.
+
+- **`getTargetTemperature`** (riga 119-132): già corretto (usa `temperatureDefaults.target ?? 21`). Verificare che `21` rientri nei bounds `[temperatureDefaults.min, temperatureDefaults.max]` — se l'utente configura `min: 25`, il default 21 sarebbe fuori range. Aggiungere clamp:
+  ```typescript
+  const min = tempDefaults.min ?? 10;
+  const max = tempDefaults.max ?? 38;
+  const defaultTemp = Math.max(min, Math.min(max, tempDefaults.target ?? 21));
+  ```
+
+- **Persistere ultimi valori noti**: in `updateStatus` (riga 208) scrivere `this.accessory.context.lastKnownTemp = newDevice.currentTemperature` così al restart il fallback è realistico.
+
+### 6. Caratteristica `Name` esplicita
+
+Tutti i costruttori chiamano `.setCharacteristic(Name, this.device.name)` su `Lightbulb`/`Thermostat`/etc. — OK. Verificare che `device.name` sia sempre non vuoto in [src/types](Sviluppo/homebridge-plugin-klares4/src/types); aggiungere fallback `device.name || 'Lares4 Device'` per non far rifiutare la registrazione Matter.
+
+### 7. `onGet` non deve mai rigettare la Promise per problemi di rete
+
+Validato: tutti gli `onGet` attuali sono effettivamente sincroni dietro `async` (leggono `this.device.status.*`). **Nessuna modifica necessaria**, ma aggiungere commento di policy in [src/accessories/light-accessory.ts](Sviluppo/homebridge-plugin-klares4/src/accessories/light-accessory.ts) (o documentare in `CLAUDE.md`/`README`): mai fare I/O di rete in `onGet`. Solo `onSet` può lanciare `HapStatusError(SERVICE_COMMUNICATION_FAILURE)`.
+
+### 8. Pulizia handler su `removeAccessory`
+
+[src/platform/accessory-registry.ts:93-107](Sviluppo/homebridge-plugin-klares4/src/platform/accessory-registry.ts#L93-L107) — già gestisce `dispose()`. Verificare che ogni handler esponga `dispose()` se sottoscrive a eventi WS (audit veloce su `light/cover/thermostat/gate/sensor/zone/scenario` — al momento nessuno lo fa esplicitamente; OK perché le sottoscrizioni vivono sul `wsClient` della platform).
+
+---
+
+## File Modificati (Riepilogo)
+
+| File | Tipo modifica |
+|---|---|
+| `package.json` | bump devDeps homebridge → 2.0-beta, @types/node → 22 |
+| `tsconfig.json` | abilitare `resolveJsonModule` se assente |
+| `src/platform/accessory-registry.ts` | eager handler init in `configureAccessory` |
+| `src/platform/plugin-version.ts` (NUOVO) | export `PLUGIN_VERSION` da package.json |
+| `src/accessories/light-accessory.ts` | serial guard + FW dinamica |
+| `src/accessories/cover-accessory.ts` | serial guard + FW dinamica |
+| `src/accessories/gate-accessory.ts` | serial guard + FW dinamica |
+| `src/accessories/sensor-accessory.ts` | serial guard + FW dinamica |
+| `src/accessories/zone-accessory.ts` | serial guard + FW dinamica |
+| `src/accessories/thermostat-accessory.ts` | serial guard + FW dinamica + clamp default + persist lastKnownTemp |
+| `src/accessories/scenario-accessory.ts` | serial guard + FW dinamica |
+
+---
+
+## Verifica End-to-End
+
+1. **Build & type-check**
+   ```bash
+   npm install
+   npm run verify   # max-lines + tsc --noEmit --noUnusedLocals + tests
+   ```
+
+2. **Test unitari**
+   ```bash
+   npm test
+   ```
+   Aggiungere un test in `test/` che simuli `configureAccessory` con un `PlatformAccessory` mock contenente `context.device` valido e verifichi che `accessoryHandlers.get(uuid)` non sia `undefined` subito dopo.
+
+3. **Smoke test in Homebridge 2.0**
+   - Installare HB 2.0-beta in un'istanza di test:
+     ```bash
+     npm install -g homebridge@beta
+     ```
+   - `npm link` il plugin nella directory di Homebridge.
+   - Avviare con `homebridge -D` e verificare nei log:
+     - `Loading accessory from cache: <name>` seguito da `Handler attached from cache for <name>` — **prima** della connessione WS.
+   - Nessun warning Matter del tipo `accessory missing characteristic handler`.
+
+4. **Test Matter pairing**
+   - In Homebridge UI → Plugin → klares4 → Bridge Settings → abilitare **Child Bridge**.
+   - Riavviare. Aprire la sezione Accessori: deve apparire QR code Matter dedicato al child bridge.
+   - In iOS app Casa → Aggiungi Accessorio → scansionare QR → tutti i dispositivi Lares4 (luci, tapparelle, termostati, sensori, scenari) devono apparire entro 30s.
+   - Toggle di una luce dall'app Casa → verifica nei log del plugin che `setOn` venga invocato e il comando WS parta.
+
+5. **Test cold-start (Matter timing)**
+   - Spegnere la centrale Ksenia (WS offline).
+   - Riavviare Homebridge.
+   - L'app Casa deve comunque mostrare gli accessori (con stato cached). Nessuno deve apparire "Non risponde" entro i primi 10s.
+   - Riaccendere la centrale → stati si aggiornano via `updateStatus`.
+
+6. **Regression HB 1.x**
+   - Ripetere smoke test con `homebridge@1.11`. Tutto deve continuare a funzionare (la modifica a `configureAccessory` è una pura anticipazione, non cambia il contratto).
+
+---
+
+## Note Operative
+
+- **Non** introdurre dipendenze a `@matter/main` o `node-matter`: Homebridge 2.0 espone gli accessori HAP a Matter automaticamente via il bridge interno. Il plugin resta un normale dynamic platform plugin.
+- **Child Bridge raccomandato**: isolare il plugin in un proprio processo riduce l'impatto di un crash WS sul resto di Homebridge ed è la configurazione testata da Apple per Matter pairing.
+- **Versioning**: dopo il merge, bump a `2.1.0` (minor — compatibilità Matter è una feature, non breaking).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "homebridge-plugin-klares4",
-    "version": "2.1.0-rc.9",
+    "version": "2.1.0-rc.10",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "homebridge-plugin-klares4",
-            "version": "2.1.0-rc.9",
+            "version": "2.1.0-rc.10",
             "license": "MIT",
             "dependencies": {
                 "mqtt": "^5.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "homebridge-plugin-klares4",
-    "version": "2.1.0-rc.4",
+    "version": "2.1.0-rc.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "homebridge-plugin-klares4",
-            "version": "2.1.0-rc.4",
+            "version": "2.1.0-rc.5",
             "license": "MIT",
             "dependencies": {
                 "mqtt": "^5.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "homebridge-plugin-klares4",
-    "version": "2.0.1",
+    "version": "2.1.0-rc.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "homebridge-plugin-klares4",
-            "version": "2.0.1",
+            "version": "2.1.0-rc.0",
             "license": "MIT",
             "dependencies": {
                 "mqtt": "^5.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "homebridge-plugin-klares4",
-    "version": "2.1.0-rc.5",
+    "version": "2.1.0-rc.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "homebridge-plugin-klares4",
-            "version": "2.1.0-rc.5",
+            "version": "2.1.0-rc.6",
             "license": "MIT",
             "dependencies": {
                 "mqtt": "^5.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "homebridge-plugin-klares4",
-    "version": "2.1.0-rc.8",
+    "version": "2.1.0-rc.9",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "homebridge-plugin-klares4",
-            "version": "2.1.0-rc.8",
+            "version": "2.1.0-rc.9",
             "license": "MIT",
             "dependencies": {
                 "mqtt": "^5.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "homebridge-plugin-klares4",
-    "version": "2.1.0-rc.3",
+    "version": "2.1.0-rc.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "homebridge-plugin-klares4",
-            "version": "2.1.0-rc.3",
+            "version": "2.1.0-rc.4",
             "license": "MIT",
             "dependencies": {
                 "mqtt": "^5.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "homebridge-plugin-klares4",
-    "version": "2.1.0-rc.7",
+    "version": "2.1.0-rc.8",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "homebridge-plugin-klares4",
-            "version": "2.1.0-rc.7",
+            "version": "2.1.0-rc.8",
             "license": "MIT",
             "dependencies": {
                 "mqtt": "^5.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,9 @@
                 "ws": "^8.14.2"
             },
             "devDependencies": {
-                "@types/node": "^20.0.0",
+                "@types/node": "^22.0.0",
                 "@types/ws": "^8.5.0",
-                "homebridge": "^1.11.1",
+                "homebridge": "^2.0.0-beta.0",
                 "typescript": "^5.0.0"
             },
             "engines": {
@@ -37,13 +37,13 @@
             }
         },
         "node_modules/@homebridge/ciao": {
-            "version": "1.3.4",
-            "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.4.tgz",
-            "integrity": "sha512-qK6ZgGx0wwOubq/MY6eTbhApQHBUQCvCOsTYpQE01uLvfA2/Prm6egySHlZouKaina1RPuDwfLhCmsRCxwHj3Q==",
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.8.tgz",
+            "integrity": "sha512-lNhpCsZVbdbjz2trFjQdzQ3cUIMZQMIMksi7wd3ntTIYgdaGLqT1Ms97DfVIJYHzRuduf56ISvgU8RRLTpK/ng==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "debug": "^4.4.1",
+                "debug": "^4.4.3",
                 "fast-deep-equal": "^3.1.3",
                 "source-map-support": "^0.5.21",
                 "tslib": "^2.8.1"
@@ -53,14 +53,14 @@
             }
         },
         "node_modules/@homebridge/dbus-native": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/@homebridge/dbus-native/-/dbus-native-0.7.2.tgz",
-            "integrity": "sha512-BNVe6YNxiy5x/E5/ZXDIWMD6Njv9cjW59PM/1CMpYe0jLAJ8pJN+Tq/JhVs3gXwmTavz2S86/sspmHquChet8A==",
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/@homebridge/dbus-native/-/dbus-native-0.7.5.tgz",
+            "integrity": "sha512-SX4Mwg7JYED+o5WMz1+Y4FzGPGtXruDcwQt1SCkzfSqMTzrFj3uO5spEMn04Jj2kCqJVcrRQFWbqw+XW8suIXA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "event-stream": "^4.0.1",
-                "hexy": "^0.3.5",
+                "hexy": "^0.4.0",
                 "long": "^5.3.2",
                 "minimist": "^1.2.8",
                 "safe-buffer": "^5.1.2",
@@ -70,6 +70,28 @@
                 "dbus2js": "bin/dbus2js.js"
             }
         },
+        "node_modules/@homebridge/hap-nodejs": {
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/@homebridge/hap-nodejs/-/hap-nodejs-2.1.6.tgz",
+            "integrity": "sha512-EZzUo9fyqfHE/FxCbRzADOEOkWOHl08LcvTqQe+fYYFkH/xSg5xO4hmGxcwQuWRte/PQqVFSWHZe69d+8XmOQg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@homebridge/ciao": "^1.3.8",
+                "@homebridge/dbus-native": "^0.7.5",
+                "bonjour-hap": "^3.10.2",
+                "debug": "^4.4.3",
+                "fast-srp-hap": "^2.0.4",
+                "futoin-hkdf": "^1.5.3",
+                "node-persist": "^0.0.12",
+                "source-map-support": "^0.5.21",
+                "tslib": "^2.8.1",
+                "tweetnacl": "^1.0.3"
+            },
+            "engines": {
+                "node": "^22 || ^24"
+            }
+        },
         "node_modules/@leichtgewicht/ip-codec": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
@@ -77,10 +99,129 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@matter/general": {
+            "version": "0.17.0-alpha.0-20260508-96d5c3a88",
+            "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.17.0-alpha.0-20260508-96d5c3a88.tgz",
+            "integrity": "sha512-YYb0OUg7j/BoNXzE4qbdOnsnMHzxwXdibHMzEujdqGBS69OTW/6uy/NW8ZrvXG9kZQ9VHCqgk+ConL8enrjUIA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@noble/curves": "^2.2.0"
+            }
+        },
+        "node_modules/@matter/main": {
+            "version": "0.17.0-alpha.0-20260508-96d5c3a88",
+            "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.17.0-alpha.0-20260508-96d5c3a88.tgz",
+            "integrity": "sha512-IXoLBk9uyrMRRRlGiyld9cDcEkFw9uMfEwGyPIVuf95F1MP7x5du8YIzhh0l4m/7BykU3jN5nbw1jyOlEsW8Cw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@matter/general": "0.17.0-alpha.0-20260508-96d5c3a88",
+                "@matter/model": "0.17.0-alpha.0-20260508-96d5c3a88",
+                "@matter/node": "0.17.0-alpha.0-20260508-96d5c3a88",
+                "@matter/protocol": "0.17.0-alpha.0-20260508-96d5c3a88",
+                "@matter/types": "0.17.0-alpha.0-20260508-96d5c3a88"
+            },
+            "optionalDependencies": {
+                "@matter/nodejs": "0.17.0-alpha.0-20260508-96d5c3a88"
+            }
+        },
+        "node_modules/@matter/model": {
+            "version": "0.17.0-alpha.0-20260508-96d5c3a88",
+            "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.17.0-alpha.0-20260508-96d5c3a88.tgz",
+            "integrity": "sha512-RiwzqkQvrwRK5v6HoArep2n7932O3F0vo1QQ6wOFs6nvHUv38WE0x3ynWAn/s0Uy9tM5RVNW46IJkZAWcfywUw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@matter/general": "0.17.0-alpha.0-20260508-96d5c3a88"
+            }
+        },
+        "node_modules/@matter/node": {
+            "version": "0.17.0-alpha.0-20260508-96d5c3a88",
+            "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.17.0-alpha.0-20260508-96d5c3a88.tgz",
+            "integrity": "sha512-Il0N4JIuY0NONT38Z0erJ9VHUVUDhBkbnfZinpMNfJewRo+tDU75lZ5F7lIkDmraMbQF4QLkld2sy/0CbEjf9Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@matter/general": "0.17.0-alpha.0-20260508-96d5c3a88",
+                "@matter/model": "0.17.0-alpha.0-20260508-96d5c3a88",
+                "@matter/protocol": "0.17.0-alpha.0-20260508-96d5c3a88",
+                "@matter/types": "0.17.0-alpha.0-20260508-96d5c3a88"
+            }
+        },
+        "node_modules/@matter/nodejs": {
+            "version": "0.17.0-alpha.0-20260508-96d5c3a88",
+            "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.17.0-alpha.0-20260508-96d5c3a88.tgz",
+            "integrity": "sha512-TRfXx9y+IvBAif7ogFMOt8ySkCdfLjh5z4ygnsfHieaPiYdZWIlWunccGqTKk9ixzGPW47Fi8iG6OF8ygBxlvA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "@matter/general": "0.17.0-alpha.0-20260508-96d5c3a88",
+                "@matter/node": "0.17.0-alpha.0-20260508-96d5c3a88",
+                "@matter/protocol": "0.17.0-alpha.0-20260508-96d5c3a88",
+                "@matter/types": "0.17.0-alpha.0-20260508-96d5c3a88"
+            },
+            "engines": {
+                "node": ">=20.19.0 <22.0.0 || >=22.13.0"
+            }
+        },
+        "node_modules/@matter/protocol": {
+            "version": "0.17.0-alpha.0-20260508-96d5c3a88",
+            "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.17.0-alpha.0-20260508-96d5c3a88.tgz",
+            "integrity": "sha512-oF09ieWRXEA2zC1uoZjIBQrgRqv86fOYJDe1kGmmjBaS4pZI/JgqOGdCkLtHXtJJ254pWM0RujtoU3DwEy81Eg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@matter/general": "0.17.0-alpha.0-20260508-96d5c3a88",
+                "@matter/model": "0.17.0-alpha.0-20260508-96d5c3a88",
+                "@matter/types": "0.17.0-alpha.0-20260508-96d5c3a88"
+            }
+        },
+        "node_modules/@matter/types": {
+            "version": "0.17.0-alpha.0-20260508-96d5c3a88",
+            "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.17.0-alpha.0-20260508-96d5c3a88.tgz",
+            "integrity": "sha512-J/VfKYRdbxIoJb6upUlaVYbvLgAq5E/pHNkr7GEB5TtBK6y2QGJkyMYggnQebtAnKLAIORcOtTk1+ZX8KrToGw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@matter/general": "0.17.0-alpha.0-20260508-96d5c3a88",
+                "@matter/model": "0.17.0-alpha.0-20260508-96d5c3a88"
+            }
+        },
+        "node_modules/@noble/curves": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+            "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@noble/hashes": "2.2.0"
+            },
+            "engines": {
+                "node": ">= 20.19.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/@noble/hashes": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+            "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20.19.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
         "node_modules/@types/node": {
-            "version": "20.19.14",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.14.tgz",
-            "integrity": "sha512-gqiKWld3YIkmtrrg9zDvg9jfksZCcPywXVN7IauUGhilwGV/yOyeUsvpR796m/Jye0zUzMXPKe8Ct1B79A7N5Q==",
+            "version": "22.19.19",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+            "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~6.21.0"
@@ -116,62 +257,6 @@
                 "node": ">=6.5"
             }
         },
-        "node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/array-buffer-byte-length": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
-            "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.3",
-                "is-array-buffer": "^3.0.5"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/array-flatten": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
-            "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/available-typed-arrays": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
-            "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "possible-typed-array-names": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/base64-js": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -205,14 +290,13 @@
             }
         },
         "node_modules/bonjour-hap": {
-            "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/bonjour-hap/-/bonjour-hap-3.9.1.tgz",
-            "integrity": "sha512-ubpbZSBwRyAx2+j5RLKFO+QuRvB02s+7rinC0rQzICx9hEc0zryjRz56Rr9lxoW7UkE/mnZ4rP4mnTCF4/iUkg==",
+            "version": "3.10.2",
+            "resolved": "https://registry.npmjs.org/bonjour-hap/-/bonjour-hap-3.10.2.tgz",
+            "integrity": "sha512-37ZEbMSKZ/K4O8sK9YDVFKJ62ZqlK4OPXcBUYaBnVlqr6vQjYwIoFuOQL0ZhztkCNgyyiCExfN4FcZB5cS9t1A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "array-flatten": "^3.0.0",
-                "deep-equal": "^2.2.3",
+                "fast-deep-equal": "^3.1.3",
                 "multicast-dns": "^7.2.5",
                 "multicast-dns-service-types": "^1.1.0"
             }
@@ -259,101 +343,27 @@
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
             "license": "MIT"
         },
-        "node_modules/call-bind": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-            "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind-apply-helpers": "^1.0.0",
-                "es-define-property": "^1.0.0",
-                "get-intrinsic": "^1.2.4",
-                "set-function-length": "^1.2.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/call-bind-apply-helpers": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "function-bind": "^1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/call-bound": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind-apply-helpers": "^1.0.2",
-                "get-intrinsic": "^1.3.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+            "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
             "engines": {
-                "node": ">=10"
+                "node": "^12.17.0 || ^14.13 || >=16.0.0"
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
-        "node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/commander": {
-            "version": "13.1.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
-            "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+            "version": "14.0.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+            "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             }
         },
         "node_modules/commist": {
@@ -408,75 +418,6 @@
                 }
             }
         },
-        "node_modules/deep-equal": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-            "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "array-buffer-byte-length": "^1.0.0",
-                "call-bind": "^1.0.5",
-                "es-get-iterator": "^1.1.3",
-                "get-intrinsic": "^1.2.2",
-                "is-arguments": "^1.1.1",
-                "is-array-buffer": "^3.0.2",
-                "is-date-object": "^1.0.5",
-                "is-regex": "^1.1.4",
-                "is-shared-array-buffer": "^1.0.2",
-                "isarray": "^2.0.5",
-                "object-is": "^1.1.5",
-                "object-keys": "^1.1.1",
-                "object.assign": "^4.1.4",
-                "regexp.prototype.flags": "^1.5.1",
-                "side-channel": "^1.0.4",
-                "which-boxed-primitive": "^1.0.2",
-                "which-collection": "^1.0.1",
-                "which-typed-array": "^1.1.13"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/define-data-property": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-define-property": "^1.0.0",
-                "es-errors": "^1.3.0",
-                "gopd": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/define-properties": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
-            "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "define-data-property": "^1.0.1",
-                "has-property-descriptors": "^1.0.0",
-                "object-keys": "^1.1.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/dns-packet": {
             "version": "5.6.1",
             "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
@@ -490,81 +431,12 @@
                 "node": ">=6"
             }
         },
-        "node_modules/dunder-proto": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind-apply-helpers": "^1.0.1",
-                "es-errors": "^1.3.0",
-                "gopd": "^1.2.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
         "node_modules/duplexer": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
             "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/es-define-property": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-errors": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-get-iterator": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
-            "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "get-intrinsic": "^1.1.3",
-                "has-symbols": "^1.0.3",
-                "is-arguments": "^1.1.1",
-                "is-map": "^2.0.2",
-                "is-set": "^2.0.2",
-                "is-string": "^1.0.7",
-                "isarray": "^2.0.5",
-                "stop-iteration-iterator": "^1.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/es-object-atoms": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
         },
         "node_modules/event-stream": {
             "version": "4.0.1",
@@ -630,22 +502,6 @@
                 "node": ">=18.2.0"
             }
         },
-        "node_modules/for-each": {
-            "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
-            "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-callable": "^1.2.7"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/from": {
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
@@ -654,9 +510,9 @@
             "license": "MIT"
         },
         "node_modules/fs-extra": {
-            "version": "11.3.2",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.2.tgz",
-            "integrity": "sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==",
+            "version": "11.3.5",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+            "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -666,26 +522,6 @@
             },
             "engines": {
                 "node": ">=14.14"
-            }
-        },
-        "node_modules/function-bind": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/functions-have-names": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-            "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/futoin-hkdf": {
@@ -698,164 +534,12 @@
                 "node": ">=8"
             }
         },
-        "node_modules/get-intrinsic": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind-apply-helpers": "^1.0.2",
-                "es-define-property": "^1.0.1",
-                "es-errors": "^1.3.0",
-                "es-object-atoms": "^1.1.1",
-                "function-bind": "^1.1.2",
-                "get-proto": "^1.0.1",
-                "gopd": "^1.2.0",
-                "has-symbols": "^1.1.0",
-                "hasown": "^2.0.2",
-                "math-intrinsics": "^1.1.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/get-proto": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "dunder-proto": "^1.0.1",
-                "es-object-atoms": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/gopd": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/graceful-fs": {
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
             "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
             "dev": true,
             "license": "ISC"
-        },
-        "node_modules/hap-nodejs": {
-            "version": "0.14.0",
-            "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.14.0.tgz",
-            "integrity": "sha512-AwvAJEP4lae6uWUb9qE+k+5uufMW38gppVOK+ujnjmJPt4DlNR5Biq2n7Q2xxiWKcWdpX328OtgGYorxbrHnlw==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@homebridge/ciao": "^1.3.4",
-                "@homebridge/dbus-native": "^0.7.2",
-                "bonjour-hap": "^3.9.1",
-                "debug": "^4.4.3",
-                "fast-srp-hap": "^2.0.4",
-                "futoin-hkdf": "^1.5.3",
-                "node-persist": "^0.0.12",
-                "source-map-support": "^0.5.21",
-                "tslib": "^2.8.1",
-                "tweetnacl": "^1.0.3"
-            },
-            "engines": {
-                "node": "^18 || ^20 || ^22 || ^24"
-            }
-        },
-        "node_modules/has-bigints": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
-            "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/has-property-descriptors": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-define-property": "^1.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/has-symbols": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/has-tostringtag": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-symbols": "^1.0.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "function-bind": "^1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
         },
         "node_modules/help-me": {
             "version": "5.0.0",
@@ -864,38 +548,39 @@
             "license": "MIT"
         },
         "node_modules/hexy": {
-            "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/hexy/-/hexy-0.3.5.tgz",
-            "integrity": "sha512-UCP7TIZPXz5kxYJnNOym+9xaenxCLor/JyhKieo8y8/bJWunGh9xbhy3YrgYJUQ87WwfXGm05X330DszOfINZw==",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/hexy/-/hexy-0.4.0.tgz",
+            "integrity": "sha512-HxJ6HCV/zrSBeAVRNEhr3CE6yTlCYklMHfCVfJkp7kC+HJqSP1SQ+howWPiHK37t++ELUtgoAoGJut5HyRhIvg==",
             "dev": true,
             "license": "MIT",
             "bin": {
                 "hexy": "bin/hexy_cmd.js"
             },
             "engines": {
-                "node": ">=10.4"
+                "node": ">=14.0.0"
             }
         },
         "node_modules/homebridge": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/homebridge/-/homebridge-1.11.1.tgz",
-            "integrity": "sha512-mZwBjnzwp2gb/Z30TAGEOXhTlywM7mfB/zNVqW7sfrq90LMFKc7eKnh7zpoybyQNyfBMpryHZRObNMh5aD+ERA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/homebridge/-/homebridge-2.0.2.tgz",
+            "integrity": "sha512-4tn8fJO+OhUskOtxt8b2LojjbyOexMurXXx7inciEOjG24mEyKrpcDkcNqdyg8xpSvuaa3Z4g1+1ANjwlwNiHg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "chalk": "4.1.2",
-                "commander": "13.1.0",
-                "fs-extra": "11.3.2",
-                "hap-nodejs": "0.14.0",
+                "@homebridge/hap-nodejs": "2.1.6",
+                "@matter/main": "0.17.0-alpha.0-20260508-96d5c3a88",
+                "chalk": "5.6.2",
+                "commander": "14.0.3",
+                "fs-extra": "11.3.5",
                 "qrcode-terminal": "0.12.0",
-                "semver": "7.7.3",
+                "semver": "7.8.0",
                 "source-map-support": "0.5.21"
             },
             "bin": {
-                "homebridge": "bin/homebridge"
+                "homebridge": "bin/homebridge.js"
             },
             "engines": {
-                "node": "^18.15.0 || ^20.7.0 || ^22 || ^24"
+                "node": "^22 || ^24"
             }
         },
         "node_modules/ieee754": {
@@ -924,21 +609,6 @@
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "license": "ISC"
         },
-        "node_modules/internal-slot": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
-            "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "hasown": "^2.0.2",
-                "side-channel": "^1.1.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
         "node_modules/ip-address": {
             "version": "10.0.1",
             "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
@@ -947,254 +617,6 @@
             "engines": {
                 "node": ">= 12"
             }
-        },
-        "node_modules/is-arguments": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
-            "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.2",
-                "has-tostringtag": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-array-buffer": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
-            "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.8",
-                "call-bound": "^1.0.3",
-                "get-intrinsic": "^1.2.6"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-bigint": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
-            "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-bigints": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-boolean-object": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
-            "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.3",
-                "has-tostringtag": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-callable": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-            "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-date-object": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
-            "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.2",
-                "has-tostringtag": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-map": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
-            "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-number-object": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
-            "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.3",
-                "has-tostringtag": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-regex": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
-            "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.2",
-                "gopd": "^1.2.0",
-                "has-tostringtag": "^1.0.2",
-                "hasown": "^2.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-set": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
-            "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-shared-array-buffer": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
-            "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-string": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
-            "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.3",
-                "has-tostringtag": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-symbol": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
-            "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.2",
-                "has-symbols": "^1.1.0",
-                "safe-regex-test": "^1.1.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-weakmap": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
-            "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-weakset": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
-            "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.3",
-                "get-intrinsic": "^1.2.6"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/isarray": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/js-sdsl": {
             "version": "4.3.0",
@@ -1207,9 +629,9 @@
             }
         },
         "node_modules/jsonfile": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-            "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+            "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1238,16 +660,6 @@
             "integrity": "sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/math-intrinsics": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
         },
         "node_modules/minimist": {
             "version": "1.2.8",
@@ -1362,67 +774,6 @@
                 "js-sdsl": "4.3.0"
             }
         },
-        "node_modules/object-inspect": {
-            "version": "1.13.4",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
-            "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/object-is": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
-            "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.7",
-                "define-properties": "^1.2.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/object-keys": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/object.assign": {
-            "version": "4.1.7",
-            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
-            "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.8",
-                "call-bound": "^1.0.3",
-                "define-properties": "^1.2.1",
-                "es-object-atoms": "^1.0.0",
-                "has-symbols": "^1.1.0",
-                "object-keys": "^1.1.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/pause-stream": {
             "version": "0.0.11",
             "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
@@ -1434,16 +785,6 @@
             ],
             "dependencies": {
                 "through": "~2.3"
-            }
-        },
-        "node_modules/possible-typed-array-names": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
-            "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
             }
         },
         "node_modules/process": {
@@ -1498,27 +839,6 @@
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
-        "node_modules/regexp.prototype.flags": {
-            "version": "1.5.4",
-            "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
-            "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.8",
-                "define-properties": "^1.2.1",
-                "es-errors": "^1.3.0",
-                "get-proto": "^1.0.1",
-                "gopd": "^1.2.0",
-                "set-function-name": "^2.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/rfdc": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
@@ -1545,35 +865,20 @@
             ],
             "license": "MIT"
         },
-        "node_modules/safe-regex-test": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
-            "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+        "node_modules/sax": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+            "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
             "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.2",
-                "es-errors": "^1.3.0",
-                "is-regex": "^1.2.1"
-            },
+            "license": "BlueOak-1.0.0",
             "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
+                "node": ">=11.0.0"
             }
         },
-        "node_modules/sax": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.3.tgz",
-            "integrity": "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==",
-            "dev": true,
-            "license": "BlueOak-1.0.0"
-        },
         "node_modules/semver": {
-            "version": "7.7.3",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-            "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+            "version": "7.8.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -1581,116 +886,6 @@
             },
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/set-function-length": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-            "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "define-data-property": "^1.1.4",
-                "es-errors": "^1.3.0",
-                "function-bind": "^1.1.2",
-                "get-intrinsic": "^1.2.4",
-                "gopd": "^1.0.1",
-                "has-property-descriptors": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/set-function-name": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
-            "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "define-data-property": "^1.1.4",
-                "es-errors": "^1.3.0",
-                "functions-have-names": "^1.2.3",
-                "has-property-descriptors": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/side-channel": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3",
-                "side-channel-list": "^1.0.0",
-                "side-channel-map": "^1.0.1",
-                "side-channel-weakmap": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/side-channel-list": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-            "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/side-channel-map": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
-            "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.2",
-                "es-errors": "^1.3.0",
-                "get-intrinsic": "^1.2.5",
-                "object-inspect": "^1.13.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/side-channel-weakmap": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
-            "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.2",
-                "es-errors": "^1.3.0",
-                "get-intrinsic": "^1.2.5",
-                "object-inspect": "^1.13.3",
-                "side-channel-map": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/smart-buffer": {
@@ -1760,20 +955,6 @@
                 "node": ">= 10.x"
             }
         },
-        "node_modules/stop-iteration-iterator": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
-            "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "internal-slot": "^1.1.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
         "node_modules/stream-combiner": {
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
@@ -1792,19 +973,6 @@
             "license": "MIT",
             "dependencies": {
                 "safe-buffer": "~5.2.0"
-            }
-        },
-        "node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/through": {
@@ -1875,67 +1043,6 @@
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "license": "MIT"
-        },
-        "node_modules/which-boxed-primitive": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
-            "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-bigint": "^1.1.0",
-                "is-boolean-object": "^1.2.1",
-                "is-number-object": "^1.1.1",
-                "is-string": "^1.1.1",
-                "is-symbol": "^1.1.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/which-collection": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
-            "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-map": "^2.0.3",
-                "is-set": "^2.0.3",
-                "is-weakmap": "^2.0.2",
-                "is-weakset": "^2.0.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/which-typed-array": {
-            "version": "1.1.19",
-            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
-            "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "available-typed-arrays": "^1.0.7",
-                "call-bind": "^1.0.8",
-                "call-bound": "^1.0.4",
-                "for-each": "^0.3.5",
-                "get-proto": "^1.0.1",
-                "gopd": "^1.2.0",
-                "has-tostringtag": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
         },
         "node_modules/worker-factory": {
             "version": "7.0.45",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "homebridge-plugin-klares4",
-    "version": "2.1.0-rc.6",
+    "version": "2.1.0-rc.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "homebridge-plugin-klares4",
-            "version": "2.1.0-rc.6",
+            "version": "2.1.0-rc.7",
             "license": "MIT",
             "dependencies": {
                 "mqtt": "^5.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "homebridge-plugin-klares4",
-    "version": "2.1.0-rc.2",
+    "version": "2.1.0-rc.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "homebridge-plugin-klares4",
-            "version": "2.1.0-rc.2",
+            "version": "2.1.0-rc.3",
             "license": "MIT",
             "dependencies": {
                 "mqtt": "^5.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "homebridge-plugin-klares4",
-    "version": "2.1.0-rc.10",
+    "version": "2.1.0-rc.11",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "homebridge-plugin-klares4",
-            "version": "2.1.0-rc.10",
+            "version": "2.1.0-rc.11",
             "license": "MIT",
             "dependencies": {
                 "mqtt": "^5.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "homebridge-plugin-klares4",
-    "version": "2.1.0-rc.0",
+    "version": "2.1.0-rc.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "homebridge-plugin-klares4",
-            "version": "2.1.0-rc.0",
+            "version": "2.1.0-rc.1",
             "license": "MIT",
             "dependencies": {
                 "mqtt": "^5.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "homebridge-plugin-klares4",
-    "version": "2.1.0-rc.1",
+    "version": "2.1.0-rc.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "homebridge-plugin-klares4",
-            "version": "2.1.0-rc.1",
+            "version": "2.1.0-rc.2",
             "license": "MIT",
             "dependencies": {
                 "mqtt": "^5.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "homebridge-plugin-klares4",
-    "version": "2.1.0-rc.8",
+    "version": "2.1.0-rc.9",
     "description": "Plugin completo per sistemi Ksenia Lares4 - Zone, Luci, Tapparelle, Termostati, Sensori",
     "main": "dist/index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "homebridge-plugin-klares4",
-    "version": "2.1.0-rc.9",
+    "version": "2.1.0-rc.10",
     "description": "Plugin completo per sistemi Ksenia Lares4 - Zone, Luci, Tapparelle, Termostati, Sensori",
     "main": "dist/index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "homebridge-plugin-klares4",
-    "version": "2.1.0-rc.2",
+    "version": "2.1.0-rc.3",
     "description": "Plugin completo per sistemi Ksenia Lares4 - Zone, Luci, Tapparelle, Termostati, Sensori",
     "main": "dist/index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "homebridge-plugin-klares4",
-    "version": "2.1.0-rc.5",
+    "version": "2.1.0-rc.6",
     "description": "Plugin completo per sistemi Ksenia Lares4 - Zone, Luci, Tapparelle, Termostati, Sensori",
     "main": "dist/index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "homebridge-plugin-klares4",
-    "version": "2.1.0-rc.7",
+    "version": "2.1.0-rc.8",
     "description": "Plugin completo per sistemi Ksenia Lares4 - Zone, Luci, Tapparelle, Termostati, Sensori",
     "main": "dist/index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "homebridge-plugin-klares4",
-    "version": "2.0.1",
+    "version": "2.1.0-rc.0",
     "description": "Plugin completo per sistemi Ksenia Lares4 - Zone, Luci, Tapparelle, Termostati, Sensori",
     "main": "dist/index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "homebridge-plugin-klares4",
-    "version": "2.1.0-rc.12",
+    "version": "2.1.0",
     "description": "Plugin completo per sistemi Ksenia Lares4 - Zone, Luci, Tapparelle, Termostati, Sensori",
     "main": "dist/index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "homebridge-plugin-klares4",
-    "version": "2.1.0-rc.10",
+    "version": "2.1.0-rc.11",
     "description": "Plugin completo per sistemi Ksenia Lares4 - Zone, Luci, Tapparelle, Termostati, Sensori",
     "main": "dist/index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "homebridge-plugin-klares4",
-    "version": "2.1.0-rc.4",
+    "version": "2.1.0-rc.5",
     "description": "Plugin completo per sistemi Ksenia Lares4 - Zone, Luci, Tapparelle, Termostati, Sensori",
     "main": "dist/index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "homebridge-plugin-klares4",
-    "version": "2.1.0-rc.3",
+    "version": "2.1.0-rc.4",
     "description": "Plugin completo per sistemi Ksenia Lares4 - Zone, Luci, Tapparelle, Termostati, Sensori",
     "main": "dist/index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "homebridge-plugin-klares4",
-    "version": "2.1.0-rc.1",
+    "version": "2.1.0-rc.2",
     "description": "Plugin completo per sistemi Ksenia Lares4 - Zone, Luci, Tapparelle, Termostati, Sensori",
     "main": "dist/index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "homebridge-plugin-klares4",
-    "version": "2.1.0-rc.0",
+    "version": "2.1.0-rc.1",
     "description": "Plugin completo per sistemi Ksenia Lares4 - Zone, Luci, Tapparelle, Termostati, Sensori",
     "main": "dist/index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "homebridge-plugin-klares4",
-    "version": "2.1.0-rc.6",
+    "version": "2.1.0-rc.7",
     "description": "Plugin completo per sistemi Ksenia Lares4 - Zone, Luci, Tapparelle, Termostati, Sensori",
     "main": "dist/index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "homebridge-plugin-klares4",
-    "version": "2.1.0-rc.11",
+    "version": "2.1.0-rc.12",
     "description": "Plugin completo per sistemi Ksenia Lares4 - Zone, Luci, Tapparelle, Termostati, Sensori",
     "main": "dist/index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
         "ws": "^8.14.2"
     },
     "devDependencies": {
-        "@types/node": "^20.0.0",
+        "@types/node": "^22.0.0",
         "@types/ws": "^8.5.0",
-        "homebridge": "^1.11.1",
+        "homebridge": "^2.0.0-beta.0",
         "typescript": "^5.0.0"
     },
     "author": {

--- a/src/accessories/cover-accessory.ts
+++ b/src/accessories/cover-accessory.ts
@@ -1,6 +1,7 @@
 import type { CharacteristicValue, PlatformAccessory, Service } from 'homebridge';
 import type { Lares4Platform, Lares4Config } from '../platform';
 import type { KseniaCover } from '../types';
+import { PLUGIN_VERSION } from '../plugin-version';
 
 /**
  * Cover Accessory Handler
@@ -31,8 +32,11 @@ export class CoverAccessory {
             accessoryInfoService
                 .setCharacteristic(this.platform.Characteristic.Manufacturer, 'Ksenia')
                 .setCharacteristic(this.platform.Characteristic.Model, 'Lares4 Cover')
-                .setCharacteristic(this.platform.Characteristic.SerialNumber, this.device.id)
-                .setCharacteristic(this.platform.Characteristic.FirmwareRevision, '2.0.1-beta0');
+                .setCharacteristic(
+                    this.platform.Characteristic.SerialNumber,
+                    this.device.id || `lares4-${accessory.UUID.slice(0, 8)}`,
+                )
+                .setCharacteristic(this.platform.Characteristic.FirmwareRevision, PLUGIN_VERSION);
         }
 
         this.service =

--- a/src/accessories/gate-accessory.ts
+++ b/src/accessories/gate-accessory.ts
@@ -1,6 +1,7 @@
 import type { CharacteristicValue, PlatformAccessory, Service } from 'homebridge';
 import type { Lares4Platform } from '../platform';
 import type { KseniaGate } from '../types';
+import { PLUGIN_VERSION } from '../plugin-version';
 
 /**
  * Gate Accessory Handler
@@ -25,8 +26,11 @@ export class GateAccessory {
             accessoryInfoService
                 .setCharacteristic(this.platform.Characteristic.Manufacturer, 'Ksenia')
                 .setCharacteristic(this.platform.Characteristic.Model, 'Lares4 Gate')
-                .setCharacteristic(this.platform.Characteristic.SerialNumber, this.device.id)
-                .setCharacteristic(this.platform.Characteristic.FirmwareRevision, '2.0.1-beta0');
+                .setCharacteristic(
+                    this.platform.Characteristic.SerialNumber,
+                    this.device.id || `lares4-${accessory.UUID.slice(0, 8)}`,
+                )
+                .setCharacteristic(this.platform.Characteristic.FirmwareRevision, PLUGIN_VERSION);
         }
 
         this.service =

--- a/src/accessories/light-accessory.ts
+++ b/src/accessories/light-accessory.ts
@@ -1,6 +1,7 @@
 import type { CharacteristicValue, PlatformAccessory, Service } from 'homebridge';
 import type { Lares4Platform } from '../platform';
 import type { KseniaLight } from '../types';
+import { PLUGIN_VERSION } from '../plugin-version';
 
 /**
  * Light Accessory Handler
@@ -23,8 +24,11 @@ export class LightAccessory {
             accessoryInfoService
                 .setCharacteristic(this.platform.Characteristic.Manufacturer, 'Ksenia')
                 .setCharacteristic(this.platform.Characteristic.Model, 'Lares4 Light')
-                .setCharacteristic(this.platform.Characteristic.SerialNumber, this.device.id)
-                .setCharacteristic(this.platform.Characteristic.FirmwareRevision, '2.0.1-beta0');
+                .setCharacteristic(
+                    this.platform.Characteristic.SerialNumber,
+                    this.device.id || `lares4-${accessory.UUID.slice(0, 8)}`,
+                )
+                .setCharacteristic(this.platform.Characteristic.FirmwareRevision, PLUGIN_VERSION);
         }
 
         this.service =

--- a/src/accessories/scenario-accessory.ts
+++ b/src/accessories/scenario-accessory.ts
@@ -2,6 +2,7 @@ import type { Service, PlatformAccessory, CharacteristicValue } from 'homebridge
 
 import type { Lares4Platform, Lares4Config } from '../platform';
 import type { KseniaScenario } from '../types';
+import { PLUGIN_VERSION } from '../plugin-version';
 
 /**
  * Scenario Accessory Handler
@@ -26,7 +27,11 @@ export class ScenarioAccessory {
             accessoryInfoService
                 .setCharacteristic(this.platform.Characteristic.Manufacturer, 'Ksenia')
                 .setCharacteristic(this.platform.Characteristic.Model, 'Lares4 Scenario')
-                .setCharacteristic(this.platform.Characteristic.SerialNumber, device.id);
+                .setCharacteristic(
+                    this.platform.Characteristic.SerialNumber,
+                    device.id || `lares4-${accessory.UUID.slice(0, 8)}`,
+                )
+                .setCharacteristic(this.platform.Characteristic.FirmwareRevision, PLUGIN_VERSION);
         }
 
         this.service =

--- a/src/accessories/sensor-accessory.ts
+++ b/src/accessories/sensor-accessory.ts
@@ -1,6 +1,7 @@
 import type { CharacteristicValue, PlatformAccessory, Service } from 'homebridge';
 import type { Lares4Platform } from '../platform';
 import type { KseniaSensor } from '../types';
+import { PLUGIN_VERSION } from '../plugin-version';
 
 /**
  * Sensor Accessory Handler
@@ -26,8 +27,11 @@ export class SensorAccessory {
                     this.platform.Characteristic.Model,
                     `Lares4 ${this.getSensorTypeLabel()}`,
                 )
-                .setCharacteristic(this.platform.Characteristic.SerialNumber, this.device.id)
-                .setCharacteristic(this.platform.Characteristic.FirmwareRevision, '2.0.1-beta0');
+                .setCharacteristic(
+                    this.platform.Characteristic.SerialNumber,
+                    this.device.id || `lares4-${accessory.UUID.slice(0, 8)}`,
+                )
+                .setCharacteristic(this.platform.Characteristic.FirmwareRevision, PLUGIN_VERSION);
         }
 
         this.service = this.createSensorService();

--- a/src/accessories/thermostat-accessory.ts
+++ b/src/accessories/thermostat-accessory.ts
@@ -1,6 +1,7 @@
 import type { CharacteristicValue, PlatformAccessory, Service } from 'homebridge';
 import type { Lares4Platform, Lares4Config } from '../platform';
 import type { KseniaThermostat } from '../types';
+import { PLUGIN_VERSION } from '../plugin-version';
 import {
     deriveHomeKitCurrentState,
     domainModeToHomeKitTarget,
@@ -15,6 +16,8 @@ import { syncThermostatTopLevelFromStatus, updateThermostatStatus } from '../the
 export class ThermostatAccessory {
     private service: Service;
     public device: KseniaThermostat;
+    private readonly tempMin: number;
+    private readonly tempMax: number;
 
     constructor(
         private readonly platform: Lares4Platform,
@@ -30,8 +33,11 @@ export class ThermostatAccessory {
             accessoryInfoService
                 .setCharacteristic(this.platform.Characteristic.Manufacturer, 'Ksenia')
                 .setCharacteristic(this.platform.Characteristic.Model, 'Lares4 Thermostat')
-                .setCharacteristic(this.platform.Characteristic.SerialNumber, this.device.id)
-                .setCharacteristic(this.platform.Characteristic.FirmwareRevision, '2.0.1-beta0');
+                .setCharacteristic(
+                    this.platform.Characteristic.SerialNumber,
+                    this.device.id || `lares4-${accessory.UUID.slice(0, 8)}`,
+                )
+                .setCharacteristic(this.platform.Characteristic.FirmwareRevision, PLUGIN_VERSION);
         }
 
         this.service =
@@ -69,9 +75,11 @@ export class ThermostatAccessory {
         }
 
         const tempDefaults = (this.platform.config as Lares4Config).temperatureDefaults ?? {};
+        this.tempMin = tempDefaults.min ?? 10;
+        this.tempMax = tempDefaults.max ?? 38;
         this.service.getCharacteristic(this.platform.Characteristic.TargetTemperature).setProps({
-            minValue: tempDefaults.min ?? 10,
-            maxValue: tempDefaults.max ?? 38,
+            minValue: this.tempMin,
+            maxValue: this.tempMax,
             minStep: tempDefaults.step ?? 0.5,
         });
 
@@ -110,8 +118,13 @@ export class ThermostatAccessory {
             this.device.currentTemperature === undefined ||
             this.device.currentTemperature === null
         ) {
-            this.platform.log.warn(`${this.device.name}: Current temperature not available`);
-            return 0;
+            // Use last persisted value from cache to avoid showing 0°C to Matter at startup.
+            const lastKnown = this.accessory.context.lastKnownTemp as number | undefined;
+            const fallback = lastKnown ?? 21;
+            this.platform.log.warn(
+                `${this.device.name}: Current temperature not available, using ${fallback}C`,
+            );
+            return Math.max(-270, Math.min(100, fallback));
         }
         return Math.max(-270, Math.min(100, this.device.currentTemperature));
     }
@@ -121,8 +134,10 @@ export class ThermostatAccessory {
             this.device.targetTemperature === undefined ||
             this.device.targetTemperature === null
         ) {
-            const defaultTemp =
+            const configTarget =
                 (this.platform.config as Lares4Config).temperatureDefaults?.target ?? 21;
+            // Clamp the default to the configured bounds so Matter bounds validation passes.
+            const defaultTemp = Math.max(this.tempMin, Math.min(this.tempMax, configTarget));
             this.platform.log.warn(
                 `${this.device.name}: Target temperature not available, using ${defaultTemp}C as default`,
             );
@@ -208,6 +223,10 @@ export class ThermostatAccessory {
     public updateStatus(newDevice: KseniaThermostat): void {
         syncThermostatTopLevelFromStatus(newDevice);
         this.device = newDevice;
+        // Persist so the next cold-start can return a realistic fallback from cache.
+        if (newDevice.currentTemperature !== undefined && newDevice.currentTemperature !== null) {
+            this.accessory.context.lastKnownTemp = newDevice.currentTemperature;
+        }
         this.service.updateCharacteristic(
             this.platform.Characteristic.CurrentTemperature,
             Math.max(-270, Math.min(100, newDevice.currentTemperature)),

--- a/src/accessories/zone-accessory.ts
+++ b/src/accessories/zone-accessory.ts
@@ -1,6 +1,7 @@
 import type { CharacteristicValue, PlatformAccessory, Service } from 'homebridge';
 import type { Lares4Platform } from '../platform';
 import type { KseniaZone } from '../types';
+import { PLUGIN_VERSION } from '../plugin-version';
 
 /**
  * Zone Accessory Handler
@@ -31,8 +32,11 @@ export class ZoneAccessory {
             accessoryInfoService
                 .setCharacteristic(this.platform.Characteristic.Manufacturer, 'Ksenia')
                 .setCharacteristic(this.platform.Characteristic.Model, 'Lares4 Security Zone')
-                .setCharacteristic(this.platform.Characteristic.SerialNumber, this.device.id)
-                .setCharacteristic(this.platform.Characteristic.FirmwareRevision, '2.0.1-beta0');
+                .setCharacteristic(
+                    this.platform.Characteristic.SerialNumber,
+                    this.device.id || `lares4-${accessory.UUID.slice(0, 8)}`,
+                )
+                .setCharacteristic(this.platform.Characteristic.FirmwareRevision, PLUGIN_VERSION);
         }
 
         this.service =

--- a/src/platform/accessory-registry.ts
+++ b/src/platform/accessory-registry.ts
@@ -30,6 +30,22 @@ export class AccessoryRegistry {
     public configureAccessory(accessory: PlatformAccessory): void {
         this.options.log.info('Loading accessory from cache:', accessory.displayName);
         this.options.accessories.set(accessory.UUID, accessory);
+
+        // Matter-readiness: the Matter bridge inspects accessories immediately at startup,
+        // before the WS discovery cycle runs. Attach the handler now from cached context.
+        const device = accessory.context?.device as KseniaDevice | undefined;
+        if (!device || !device.id) {
+            this.options.log.warn(
+                `Skipping cache handler init for ${accessory.displayName}: missing device context`,
+            );
+            return;
+        }
+
+        const handler = this.options.createAccessoryHandler(accessory, device);
+        if (handler) {
+            this.options.accessoryHandlers.set(accessory.UUID, handler);
+            this.options.log.debug(`Handler attached from cache for ${device.name}`);
+        }
     }
 
     public addAccessory(device: KseniaDevice): void {

--- a/src/platform/index.ts
+++ b/src/platform/index.ts
@@ -78,11 +78,13 @@ export class Lares4Platform implements DynamicPlatformPlugin {
             updateAccessoryHandler: (handler, device): void =>
                 this.handlerService.updateAccessoryHandler(handler, device),
         });
-        this.matterRegistry = new MatterAccessoryRegistry(
-            this.api,
-            this.log,
-            () => this.wsClient,
-        );
+        this.matterRegistry = new MatterAccessoryRegistry({
+            api: this.api,
+            log: this.log,
+            getWsClient: () => this.wsClient,
+            storagePath: this.api.user.storagePath(),
+            momentaryAutoOffMs: this.config?.scenarioAutoOffDelay,
+        });
 
         if (!config) {
             this.log.error('No configuration found');

--- a/src/platform/index.ts
+++ b/src/platform/index.ts
@@ -3,6 +3,7 @@ import type {
     Characteristic,
     DynamicPlatformPlugin,
     Logger,
+    MatterAccessory,
     PlatformAccessory,
     Service,
 } from 'homebridge';
@@ -15,6 +16,7 @@ import { KseniaWebSocketClient } from '../websocket-client';
 import { DebugCaptureManager } from '../debug-capture';
 import { AccessoryRegistry } from './accessory-registry';
 import { AccessoryHandlerService } from './accessory-handler-service';
+import { MatterAccessoryRegistry } from './matter-accessory-registry';
 import { PlatformConfigFileService } from './config-file-service';
 import { DeviceListService } from './device-list-service';
 import { DiscoveryService } from './discovery-service';
@@ -36,6 +38,7 @@ export class Lares4Platform implements DynamicPlatformPlugin {
     private readonly discoveredDevices: Map<string, KseniaDevice> = new Map();
     private readonly activeDiscoveredUUIDs: Set<string> = new Set();
     private readonly accessoryRegistry: AccessoryRegistry;
+    private readonly matterRegistry: MatterAccessoryRegistry;
     private readonly discoveryService: DiscoveryService;
     private readonly lifecycleService: PlatformLifecycleService;
     private readonly deviceListService: DeviceListService;
@@ -75,6 +78,11 @@ export class Lares4Platform implements DynamicPlatformPlugin {
             updateAccessoryHandler: (handler, device): void =>
                 this.handlerService.updateAccessoryHandler(handler, device),
         });
+        this.matterRegistry = new MatterAccessoryRegistry(
+            this.api,
+            this.log,
+            () => this.wsClient,
+        );
 
         if (!config) {
             this.log.error('No configuration found');
@@ -105,10 +113,15 @@ export class Lares4Platform implements DynamicPlatformPlugin {
         });
     }
 
+    public configureMatterAccessory(accessory: MatterAccessory): void {
+        this.matterRegistry.configureCachedAccessory(accessory);
+    }
+
     private async initializeLares4(): Promise<void> {
         try {
             this.log.info('Initializing Ksenia Lares4 connection...');
             this.accessoryRegistry.startDiscoveryCycle();
+            this.matterRegistry.startDiscoveryCycle();
 
             const useHttps = this.config.https !== false;
             const port = this.config.port ?? (useHttps ? 443 : 80);
@@ -179,6 +192,9 @@ export class Lares4Platform implements DynamicPlatformPlugin {
     private handleInitialSyncComplete(): void {
         this.log.info('Initial synchronization completed, pruning stale accessories...');
         this.accessoryRegistry.pruneStaleAccessories();
+        this.matterRegistry.pruneStaleAccessories().catch((err: unknown) => {
+            this.log.warn('[Matter] Prune error:', err instanceof Error ? err.message : String(err));
+        });
     }
 
     private cleanupConnections(): void {
@@ -200,12 +216,18 @@ export class Lares4Platform implements DynamicPlatformPlugin {
         this.discoveryService.applyCustomName(device);
         this.log.info(`Device discovered: ${device.type} - ${device.name}`);
         this.addAccessory(device);
+        this.matterRegistry.addOrUpdateAccessory(device).catch((err: unknown) => {
+            this.log.warn(`[Matter] Registration error for ${device.name}:`, err instanceof Error ? err.message : String(err));
+        });
     }
 
     private handleDeviceStatusUpdate(device: KseniaDevice): void {
         this.log.debug(`Device status update: ${device.name}`);
         this.updateAccessory(device);
         this.mqttBridge?.publishDeviceState(device);
+        this.matterRegistry.updateAccessoryState(device).catch((err: unknown) => {
+            this.log.debug(`[Matter] State update error for ${device.name}:`, err instanceof Error ? err.message : String(err));
+        });
     }
 
     public configureAccessory(accessory: PlatformAccessory): void {

--- a/src/platform/matter-accessory-registry.ts
+++ b/src/platform/matter-accessory-registry.ts
@@ -1,19 +1,63 @@
 import type { API, Logger } from 'homebridge';
 import type { MatterAccessory } from 'homebridge';
-import type { KseniaDevice } from '../types';
+import type { KseniaDevice, KseniaThermostat } from '../types';
 import { PLUGIN_NAME, PLATFORM_NAME } from '../settings';
 import type { KseniaWebSocketClient } from '../websocket-client';
-import { deviceToMatterAccessory, toCentidegrees, clampCentidegrees, domainModeToMatterMode } from './matter-device-mapper';
+import {
+    deviceToMatterAccessory,
+    mapThermostatAsTemperatureSensor,
+} from './matter-device-mapper';
+import { buildStateUpdates, type PendingMatterStateUpdate } from './matter-state-updates';
+
+// ---------------------------------------------------------------------------
+// Configuration knobs
+// ---------------------------------------------------------------------------
+
+/**
+ * Time to wait between calling `api.matter.registerPlatformAccessories(...)` and
+ * trusting that the accessory is queryable via `api.matter.updateAccessoryState(...)`.
+ * HB2's register API is fire-and-forget (it just emits an internal event); state
+ * updates received in this window are buffered.
+ */
+const MATTER_REGISTER_SETTLE_MS = 2000;
+
+/**
+ * Whether to fall back to a Matter TemperatureSensor when registering a real
+ * Thermostat fails (typically due to matter.js 0.17 `presetTypes` validation).
+ * HAP continues to expose the full Thermostat regardless.
+ */
+const MATTER_THERMOSTAT_FALLBACK_TO_TEMPERATURE_SENSOR = true;
+
+// ---------------------------------------------------------------------------
+// Registration state machine
+// ---------------------------------------------------------------------------
+
+export type MatterRegistrationStatus = 'pending' | 'registered' | 'failed' | 'skipped';
+
+interface MatterRegistration {
+    uuid: string;
+    displayName: string;
+    deviceType: string; // Lares4 device type, used for fallback decisions
+    status: MatterRegistrationStatus;
+    registeredAt?: number;
+    failedAt?: number;
+    lastError?: string;
+    pendingStateUpdates: PendingMatterStateUpdate[];
+}
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
 
 export class MatterAccessoryRegistry {
+    /** UUIDs that HB2 reported to us via `configureMatterAccessory` (cache restore). */
     private readonly cachedUUIDs: Set<string> = new Set();
-    private readonly registeredUUIDs: Set<string> = new Set();
-    private readonly failedUUIDs: Set<string> = new Set();
-    // Tracks when each UUID was registered — state updates are deferred until the IPC commit
-    // has had time to complete (HB2 registerPlatformAccessories is fire-and-forget on the API side).
-    private readonly registeredAt: Map<string, number> = new Map();
-    private static readonly REGISTER_SETTLE_MS = 2000;
+    /** Full registration state, keyed by Lares device id (also the Matter UUID). */
+    private readonly registrations: Map<string, MatterRegistration> = new Map();
+    /** UUIDs we've seen in the current discovery cycle — used to prune stale ones. */
     private activeDiscoveredUUIDs: Set<string> = new Set();
+    /** UUIDs that fell back to TemperatureSensor — drive the alternate state-push path. */
+    private readonly thermostatFallbackUUIDs: Set<string> = new Set();
 
     constructor(
         private readonly api: API,
@@ -24,6 +68,10 @@ export class MatterAccessoryRegistry {
     public get isEnabled(): boolean {
         return !!this.api.matter;
     }
+
+    // -----------------------------------------------------------------------
+    // Lifecycle hooks called by Platform
+    // -----------------------------------------------------------------------
 
     public configureCachedAccessory(accessory: MatterAccessory): void {
         this.cachedUUIDs.add(accessory.UUID);
@@ -36,188 +84,211 @@ export class MatterAccessoryRegistry {
 
     public async addOrUpdateAccessory(device: KseniaDevice): Promise<void> {
         if (!this.api.matter) return;
-        // Skip devices whose registration has previously failed — retrying floods logs with
-        // identical Behavior errors and never recovers within a single process lifetime.
-        if (this.failedUUIDs.has(device.id)) return;
+        this.activeDiscoveredUUIDs.add(device.id);
 
+        const existing = this.registrations.get(device.id);
+        if (existing) {
+            // Already known — either still pending the settle window, registered, failed or skipped.
+            switch (existing.status) {
+                case 'pending':
+                    // Queue the latest state; the settle handler will flush it.
+                    this.enqueueStateFor(device);
+                    return;
+                case 'registered':
+                    await this.pushStateUpdate(device);
+                    return;
+                case 'failed':
+                case 'skipped':
+                    return; // silent, we've already logged once
+            }
+        }
+
+        await this.registerAccessory(device);
+    }
+
+    public async updateAccessoryState(device: KseniaDevice): Promise<void> {
+        if (!this.api.matter) return;
+        const existing = this.registrations.get(device.id);
+
+        if (!existing) {
+            // First time we see this device — register it (lazy path for HAP-cached devices
+            // whose WS "discovered" callback hasn't fired yet).
+            await this.registerAccessory(device);
+            return;
+        }
+
+        switch (existing.status) {
+            case 'pending':
+                this.enqueueStateFor(device);
+                return;
+            case 'registered':
+                await this.pushStateUpdate(device);
+                return;
+            case 'failed':
+            case 'skipped':
+                return;
+        }
+    }
+
+    public async pruneStaleAccessories(): Promise<void> {
+        if (!this.api.matter) return;
+        for (const [uuid, reg] of this.registrations) {
+            if (reg.status !== 'registered') continue;
+            if (this.activeDiscoveredUUIDs.has(uuid)) continue;
+            this.log.info(`[Matter] Removing stale accessory: ${reg.displayName} (${uuid})`);
+            try {
+                await this.api.matter.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [
+                    { UUID: uuid } as MatterAccessory,
+                ]);
+                this.registrations.delete(uuid);
+                this.cachedUUIDs.delete(uuid);
+                this.thermostatFallbackUUIDs.delete(uuid);
+            } catch (err) {
+                this.log.warn(`[Matter] Failed to unregister ${uuid}: ${this.fmtErr(err)}`);
+            }
+        }
+    }
+
+    /** Test-only introspection: registration status for a given device id. */
+    public getStatus(uuid: string): MatterRegistrationStatus | undefined {
+        return this.registrations.get(uuid)?.status;
+    }
+
+    /** Test-only introspection: queued updates count for a device id. */
+    public getPendingCount(uuid: string): number {
+        return this.registrations.get(uuid)?.pendingStateUpdates.length ?? 0;
+    }
+
+    // -----------------------------------------------------------------------
+    // Registration internals
+    // -----------------------------------------------------------------------
+
+    private async registerAccessory(device: KseniaDevice): Promise<void> {
         const matterAccessory = deviceToMatterAccessory(device, {
             api: this.api,
             log: this.log,
             getWsClient: this.getWsClient,
         });
+        if (!matterAccessory) return;
 
-        if (!matterAccessory) {
-            return;
-        }
-
-        this.activeDiscoveredUUIDs.add(device.id);
-
-        if (this.registeredUUIDs.has(device.id)) {
-            // Already registered — push state, but only if past the IPC settle window.
-            const registeredAt = this.registeredAt.get(device.id) ?? 0;
-            if (Date.now() - registeredAt >= MatterAccessoryRegistry.REGISTER_SETTLE_MS) {
-                await this.pushStateUpdate(device);
-            }
-            return;
-        }
+        const reg: MatterRegistration = {
+            uuid: device.id,
+            displayName: device.name,
+            deviceType: device.type,
+            status: 'pending',
+            pendingStateUpdates: [],
+        };
+        this.registrations.set(device.id, reg);
 
         const fromCache = this.cachedUUIDs.has(device.id);
-        if (fromCache) {
-            this.log.debug(`[Matter] Restoring cached accessory: ${device.name}`);
-        } else {
-            this.log.info(`[Matter] Registering new accessory: ${device.name} (${device.type})`);
-        }
+        this.log.info(`[Matter] register requested: ${device.name} (${device.type})${fromCache ? ' [cache restore]' : ''}`);
 
         try {
-            await this.api.matter.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [matterAccessory]);
-            this.registeredUUIDs.add(device.id);
-            this.registeredAt.set(device.id, Date.now());
-            this.log.info(`[Matter] Registered: ${device.name}`);
-            // Do NOT push state immediately — registerPlatformAccessories is fire-and-forget on the
-            // API side (emits an event, doesn't await commit). The initial clusters payload in the
-            // MatterAccessory already carries the current state, so the next status update will
-            // catch up after REGISTER_SETTLE_MS.
+            await this.api.matter!.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [matterAccessory]);
         } catch (err) {
-            this.failedUUIDs.add(device.id);
-            this.log.warn(`[Matter] Failed to register ${device.name} — will not retry this session: ${err instanceof Error ? err.message : String(err)}`);
-        }
-    }
-
-    public async updateAccessoryState(device: KseniaDevice): Promise<void> {
-        if (!this.api.matter) return;
-        // Skip devices that we've already failed to register — avoids log spam.
-        if (this.failedUUIDs.has(device.id)) return;
-        // Lazy registration: an HAP status update can arrive before the WS "discovered" callback,
-        // especially for accessories already in HAP cache. Register on the fly so we don't miss any.
-        if (!this.registeredUUIDs.has(device.id)) {
-            await this.addOrUpdateAccessory(device);
+            await this.handleRegisterFailure(device, err);
             return;
         }
-        // Skip state pushes during the IPC settle window — the registration event hasn't been
-        // processed by the Matter server yet, so updateAccessoryState would fail with "not found".
-        const registeredAt = this.registeredAt.get(device.id) ?? 0;
-        if (Date.now() - registeredAt < MatterAccessoryRegistry.REGISTER_SETTLE_MS) {
-            return;
-        }
-        await this.pushStateUpdate(device);
+
+        this.log.debug(`[Matter] settle started (${MATTER_REGISTER_SETTLE_MS}ms): ${device.name}`);
+        // Don't `await` the settle timer — let the WS event loop continue. Queued updates
+        // are stored on the registration; we flush them when the timer fires.
+        setTimeout(() => { void this.completeRegistration(device.id); }, MATTER_REGISTER_SETTLE_MS);
     }
 
-    public async pruneStaleAccessories(): Promise<void> {
-        if (!this.api.matter) return;
+    private async completeRegistration(uuid: string): Promise<void> {
+        const reg = this.registrations.get(uuid);
+        if (!reg || reg.status !== 'pending') return;
 
-        for (const uuid of this.registeredUUIDs) {
-            if (!this.activeDiscoveredUUIDs.has(uuid)) {
-                this.log.info(`[Matter] Removing stale accessory: ${uuid}`);
-                try {
-                    await this.api.matter.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [
-                        { UUID: uuid } as MatterAccessory,
-                    ]);
-                    this.registeredUUIDs.delete(uuid);
-                    this.cachedUUIDs.delete(uuid);
-                } catch (err) {
-                    this.log.warn(`[Matter] Failed to unregister ${uuid}: ${err instanceof Error ? err.message : String(err)}`);
-                }
+        reg.status = 'registered';
+        reg.registeredAt = Date.now();
+        this.log.info(`[Matter] registered: ${reg.displayName}`);
+
+        if (reg.pendingStateUpdates.length === 0) return;
+
+        const flushed = reg.pendingStateUpdates.splice(0);
+        this.log.debug(`[Matter] pending updates flushed: ${reg.displayName} (${flushed.length})`);
+        for (const update of flushed) {
+            try {
+                await this.api.matter!.updateAccessoryState(uuid, update.clusterName, update.attributes, update.partId);
+            } catch (err) {
+                this.log.debug(`[Matter] post-settle update error for ${reg.displayName}: ${this.fmtErr(err)}`);
             }
         }
     }
+
+    /**
+     * Centralised handler for failed initial registration. Currently only used for thermostats —
+     * other device types are simply marked failed and skipped for the session.
+     */
+    private async handleRegisterFailure(device: KseniaDevice, err: unknown): Promise<void> {
+        const reg = this.registrations.get(device.id)!;
+        const msg = this.fmtErr(err);
+
+        if (device.type === 'thermostat' && MATTER_THERMOSTAT_FALLBACK_TO_TEMPERATURE_SENSOR) {
+            this.log.warn(
+                `Matter Thermostat registration failed for ${device.name}; falling back to TemperatureSensor `
+                + `due to matter.js thermostat presetTypes validation issue. Error: ${msg}`,
+            );
+            const fallback = mapThermostatAsTemperatureSensor(device as KseniaThermostat, {
+                api: this.api,
+                log: this.log,
+                getWsClient: this.getWsClient,
+            });
+            try {
+                await this.api.matter!.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [fallback]);
+                this.thermostatFallbackUUIDs.add(device.id);
+                this.log.debug(`[Matter] settle started (${MATTER_REGISTER_SETTLE_MS}ms): ${device.name} [fallback]`);
+                setTimeout(() => { void this.completeRegistration(device.id); }, MATTER_REGISTER_SETTLE_MS);
+                return;
+            } catch (fbErr) {
+                this.log.warn(`[Matter] Fallback TemperatureSensor also failed for ${device.name}: ${this.fmtErr(fbErr)}`);
+            }
+        }
+
+        reg.status = 'failed';
+        reg.failedAt = Date.now();
+        reg.lastError = msg;
+        reg.pendingStateUpdates = [];
+        this.log.warn(`[Matter] accessory failed: ${device.name} — ${msg}`);
+    }
+
+    // -----------------------------------------------------------------------
+    // State propagation
+    // -----------------------------------------------------------------------
 
     private async pushStateUpdate(device: KseniaDevice): Promise<void> {
+        const updates = this.buildUpdatesFor(device);
         const matter = this.api.matter!;
-        const uuid = device.id;
-
-        try {
-            switch (device.type) {
-                case 'light':
-                    await matter.updateAccessoryState(uuid, 'onOff', { onOff: device.status.on });
-                    if (device.status.dimmable && device.status.brightness !== undefined) {
-                        await matter.updateAccessoryState(uuid, 'levelControl', {
-                            currentLevel: Math.round((device.status.brightness / 100) * 254),
-                        });
-                    }
-                    break;
-
-                case 'cover': {
-                    const matterPos = Math.round((100 - (device.status.position ?? 0)) * 100);
-                    await matter.updateAccessoryState(uuid, 'windowCovering', {
-                        currentPositionLiftPercent100ths: matterPos,
-                        targetPositionLiftPercent100ths: matterPos,
-                    });
-                    break;
-                }
-
-                case 'thermostat': {
-                    const current = device.currentTemperature ?? 21;
-                    const target = device.targetTemperature ?? 21;
-                    const mode = device.mode ?? 'heat';
-                    const HEAT_MIN = 700, HEAT_MAX = 3000;
-                    const COOL_MIN = 1600, COOL_MAX = 3200;
-                    const DEADBAND_CENTI = 250;
-                    const heatingSetpoint = Math.max(HEAT_MIN, Math.min(HEAT_MAX, toCentidegrees(target)));
-                    const coolingSetpoint = Math.max(COOL_MIN, Math.min(COOL_MAX, heatingSetpoint + DEADBAND_CENTI));
-                    await matter.updateAccessoryState(uuid, 'thermostat', {
-                        localTemperature: clampCentidegrees(toCentidegrees(current)),
-                        occupiedHeatingSetpoint: heatingSetpoint,
-                        occupiedCoolingSetpoint: coolingSetpoint,
-                        unoccupiedHeatingSetpoint: heatingSetpoint,
-                        unoccupiedCoolingSetpoint: coolingSetpoint,
-                        systemMode: domainModeToMatterMode(mode),
-                    });
-                    break;
-                }
-
-                case 'sensor': {
-                    const val = device.status.value;
-                    switch (device.status.sensorType) {
-                        case 'temperature':
-                            await matter.updateAccessoryState(uuid, 'temperatureMeasurement', {
-                                measuredValue: clampCentidegrees(toCentidegrees(val)),
-                            });
-                            break;
-                        case 'humidity':
-                            await matter.updateAccessoryState(uuid, 'relativeHumidityMeasurement', {
-                                measuredValue: Math.round(Math.max(0, Math.min(100, val)) * 100),
-                            });
-                            break;
-                        case 'light':
-                            await matter.updateAccessoryState(uuid, 'illuminanceMeasurement', {
-                                measuredValue: val <= 0 ? 0 : Math.max(1, Math.min(65534, Math.round(10000 * Math.log10(val) + 1))),
-                            });
-                            break;
-                        case 'motion':
-                            await matter.updateAccessoryState(uuid, 'occupancySensing', {
-                                occupancy: { occupied: val > 0 },
-                            });
-                            break;
-                        case 'contact':
-                            await matter.updateAccessoryState(uuid, 'booleanState', {
-                                stateValue: val === 0,
-                            });
-                            break;
-                    }
-                    break;
-                }
-
-                case 'zone':
-                    await matter.updateAccessoryState(uuid, 'booleanState', {
-                        stateValue: !device.status.open,
-                    });
-                    break;
-
-                case 'scenario':
-                    await matter.updateAccessoryState(uuid, 'onOff', {
-                        onOff: device.status.active,
-                    });
-                    break;
-
-                case 'gate':
-                    await matter.updateAccessoryState(uuid, 'onOff', {
-                        onOff: device.status.on,
-                    });
-                    break;
+        for (const u of updates) {
+            try {
+                await matter.updateAccessoryState(device.id, u.clusterName, u.attributes, u.partId);
+            } catch (err) {
+                this.log.debug(`[Matter] update failed for ${device.name} (${u.clusterName}): ${this.fmtErr(err)}`);
             }
-        } catch (err) {
-            this.log.debug(`[Matter] State update error for ${uuid}: ${err instanceof Error ? err.message : String(err)}`);
         }
     }
-}
 
+    private enqueueStateFor(device: KseniaDevice): void {
+        const reg = this.registrations.get(device.id);
+        if (!reg) return;
+        for (const u of this.buildUpdatesFor(device)) {
+            // Dedupe by (clusterName, partId) — keep only the latest payload per slot.
+            const idx = reg.pendingStateUpdates.findIndex(
+                (p) => p.clusterName === u.clusterName && p.partId === u.partId,
+            );
+            if (idx >= 0) reg.pendingStateUpdates[idx] = u;
+            else reg.pendingStateUpdates.push(u);
+        }
+        this.log.debug(`[Matter] update queued: ${device.name} (pending=${reg.pendingStateUpdates.length})`);
+    }
+
+    private buildUpdatesFor(device: KseniaDevice): PendingMatterStateUpdate[] {
+        const isFallback = device.type === 'thermostat' && this.thermostatFallbackUUIDs.has(device.id);
+        return buildStateUpdates(device, isFallback);
+    }
+
+    private fmtErr(err: unknown): string {
+        return err instanceof Error ? err.message : String(err);
+    }
+}

--- a/src/platform/matter-accessory-registry.ts
+++ b/src/platform/matter-accessory-registry.ts
@@ -51,12 +51,14 @@ export class MatterAccessoryRegistry {
         }
 
         if (this.cachedUUIDs.has(device.id)) {
-            // Known from cache — re-register with fresh state (handles handler re-attachment)
-            this.log.debug(`[Matter] Restoring cached accessory: ${device.name}`);
-        } else {
-            this.log.info(`[Matter] Registering new accessory: ${device.name} (${device.type})`);
+            // Already restored from cache by HB2 — handlers re-attached. Just track and push state.
+            this.log.debug(`[Matter] Restored from cache: ${device.name}`);
+            this.registeredUUIDs.add(device.id);
+            await this.pushStateUpdate(device);
+            return;
         }
 
+        this.log.info(`[Matter] Registering new accessory: ${device.name} (${device.type})`);
         try {
             await this.api.matter.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [matterAccessory]);
             this.registeredUUIDs.add(device.id);

--- a/src/platform/matter-accessory-registry.ts
+++ b/src/platform/matter-accessory-registry.ts
@@ -11,6 +11,7 @@ import {
     registerFallbackAccessory,
     type MatterRegistration,
 } from './matter-registration-recovery';
+import { MatterStateUpdateQueue } from './matter-state-update-queue';
 
 // ---------------------------------------------------------------------------
 // Configuration knobs
@@ -46,6 +47,7 @@ export class MatterAccessoryRegistry {
     private readonly cachedUUIDs: Set<string> = new Set();
     /** Full registration state, keyed by Lares device id (also the Matter UUID). */
     private readonly registrations: Map<string, MatterRegistration> = new Map();
+    private readonly stateUpdateQueue: MatterStateUpdateQueue;
     /** UUIDs we've seen in the current discovery cycle — used to prune stale ones. */
     private activeDiscoveredUUIDs: Set<string> = new Set();
     /** UUIDs that fell back to TemperatureSensor — drive the alternate state-push path. */
@@ -55,7 +57,14 @@ export class MatterAccessoryRegistry {
         private readonly api: API,
         private readonly log: Logger,
         private readonly getWsClient: () => KseniaWebSocketClient | undefined,
-    ) {}
+    ) {
+        this.stateUpdateQueue = new MatterStateUpdateQueue(
+            this.api,
+            this.log,
+            this.registrations,
+            (err) => this.fmtErr(err),
+        );
+    }
 
     public get isEnabled(): boolean {
         return !!this.api.matter;
@@ -205,17 +214,7 @@ export class MatterAccessoryRegistry {
         this.log.info(`[Matter] registered: ${reg.displayName}`);
         await this.updateCachedAccessoryMetadata(reg);
 
-        if (reg.pendingStateUpdates.length === 0) return;
-
-        const flushed = reg.pendingStateUpdates.splice(0);
-        this.log.debug(`[Matter] pending updates flushed: ${reg.displayName} (${flushed.length})`);
-        for (const update of flushed) {
-            try {
-                await this.api.matter!.updateAccessoryState(uuid, update.clusterName, update.attributes, update.partId);
-            } catch (err) {
-                this.log.debug(`[Matter] post-settle update error for ${reg.displayName}: ${this.fmtErr(err)}`);
-            }
-        }
+        this.stateUpdateQueue.scheduleFlush(uuid, 0);
     }
 
     /**
@@ -251,14 +250,12 @@ export class MatterAccessoryRegistry {
     // -----------------------------------------------------------------------
 
     private async pushStateUpdate(device: KseniaDevice): Promise<void> {
+        const reg = this.registrations.get(device.id);
+        if (!reg) return;
+
         const updates = this.buildUpdatesFor(device);
-        const matter = this.api.matter!;
         for (const u of updates) {
-            try {
-                await matter.updateAccessoryState(device.id, u.clusterName, u.attributes, u.partId);
-            } catch (err) {
-                this.log.debug(`[Matter] update failed for ${device.name} (${u.clusterName}): ${this.fmtErr(err)}`);
-            }
+            await this.stateUpdateQueue.pushOrQueue(reg, u);
         }
     }
 

--- a/src/platform/matter-accessory-registry.ts
+++ b/src/platform/matter-accessory-registry.ts
@@ -3,11 +3,14 @@ import type { MatterAccessory } from 'homebridge';
 import type { KseniaDevice, KseniaThermostat } from '../types';
 import { PLUGIN_NAME, PLATFORM_NAME } from '../settings';
 import type { KseniaWebSocketClient } from '../websocket-client';
-import {
-    deviceToMatterAccessory,
-    mapThermostatAsTemperatureSensor,
-} from './matter-device-mapper';
+import { deviceToMatterAccessory } from './matter-device-mapper';
 import { buildStateUpdates, type PendingMatterStateUpdate } from './matter-state-updates';
+import {
+    handleMissingRegisteredAccessory,
+    isMatterAccessoryQueryable,
+    registerFallbackAccessory,
+    type MatterRegistration,
+} from './matter-registration-recovery';
 
 // ---------------------------------------------------------------------------
 // Configuration knobs
@@ -33,18 +36,6 @@ const MATTER_THERMOSTAT_FALLBACK_TO_TEMPERATURE_SENSOR = true;
 // ---------------------------------------------------------------------------
 
 export type MatterRegistrationStatus = 'pending' | 'registered' | 'failed' | 'skipped';
-
-interface MatterRegistration {
-    uuid: string;
-    displayName: string;
-    deviceType: string; // Lares4 device type, used for fallback decisions
-    matterAccessory: MatterAccessory;
-    status: MatterRegistrationStatus;
-    registeredAt?: number;
-    failedAt?: number;
-    lastError?: string;
-    pendingStateUpdates: PendingMatterStateUpdate[];
-}
 
 // ---------------------------------------------------------------------------
 // Registry
@@ -179,6 +170,7 @@ export class MatterAccessoryRegistry {
             deviceType: device.type,
             matterAccessory,
             status: 'pending',
+            recoveryAttempts: 0,
             pendingStateUpdates: [],
         };
         this.registrations.set(device.id, reg);
@@ -196,12 +188,17 @@ export class MatterAccessoryRegistry {
         this.log.debug(`[Matter] settle started (${MATTER_REGISTER_SETTLE_MS}ms): ${device.name}`);
         // Don't `await` the settle timer — let the WS event loop continue. Queued updates
         // are stored on the registration; we flush them when the timer fires.
-        setTimeout(() => { void this.completeRegistration(device.id); }, MATTER_REGISTER_SETTLE_MS);
+        this.scheduleComplete(device.id);
     }
 
     private async completeRegistration(uuid: string): Promise<void> {
         const reg = this.registrations.get(uuid);
         if (!reg || reg.status !== 'pending') return;
+
+        if (!await isMatterAccessoryQueryable(this.api, this.log, (err) => this.fmtErr(err), reg)) {
+            await handleMissingRegisteredAccessory(reg, this.recoveryDeps());
+            return;
+        }
 
         reg.status = 'registered';
         reg.registeredAt = Date.now();
@@ -234,17 +231,8 @@ export class MatterAccessoryRegistry {
                 `Matter Thermostat registration failed for ${device.name}; falling back to TemperatureSensor `
                 + `due to matter.js thermostat presetTypes validation issue. Error: ${msg}`,
             );
-            const fallback = mapThermostatAsTemperatureSensor(device as KseniaThermostat, {
-                api: this.api,
-                log: this.log,
-                getWsClient: this.getWsClient,
-            });
             try {
-                await this.api.matter!.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [fallback]);
-                this.thermostatFallbackUUIDs.add(device.id);
-                reg.matterAccessory = fallback;
-                this.log.debug(`[Matter] settle started (${MATTER_REGISTER_SETTLE_MS}ms): ${device.name} [fallback]`);
-                setTimeout(() => { void this.completeRegistration(device.id); }, MATTER_REGISTER_SETTLE_MS);
+                await registerFallbackAccessory(device as KseniaThermostat, reg, this.recoveryDeps());
                 return;
             } catch (fbErr) {
                 this.log.warn(`[Matter] Fallback TemperatureSensor also failed for ${device.name}: ${this.fmtErr(fbErr)}`);
@@ -277,6 +265,7 @@ export class MatterAccessoryRegistry {
     private enqueueStateFor(device: KseniaDevice): void {
         const reg = this.registrations.get(device.id);
         if (!reg) return;
+        reg.matterAccessory.context.device = device;
         for (const u of this.buildUpdatesFor(device)) {
             // Dedupe by (clusterName, partId) — keep only the latest payload per slot.
             const idx = reg.pendingStateUpdates.findIndex(
@@ -327,5 +316,22 @@ export class MatterAccessoryRegistry {
 
     private fmtErr(err: unknown): string {
         return err instanceof Error ? err.message : String(err);
+    }
+
+    private scheduleComplete(uuid: string): void {
+        setTimeout(() => { void this.completeRegistration(uuid); }, MATTER_REGISTER_SETTLE_MS);
+    }
+
+    private recoveryDeps(): Parameters<typeof handleMissingRegisteredAccessory>[1] {
+        return {
+            api: this.api,
+            log: this.log,
+            thermostatFallbackUUIDs: this.thermostatFallbackUUIDs,
+            getWsClient: this.getWsClient,
+            scheduleComplete: (uuid) => this.scheduleComplete(uuid),
+            fmtErr: (err) => this.fmtErr(err),
+            settleMs: MATTER_REGISTER_SETTLE_MS,
+            thermostatFallbackEnabled: MATTER_THERMOSTAT_FALLBACK_TO_TEMPERATURE_SENSOR,
+        };
     }
 }

--- a/src/platform/matter-accessory-registry.ts
+++ b/src/platform/matter-accessory-registry.ts
@@ -1,0 +1,189 @@
+import type { API, Logger } from 'homebridge';
+import type { MatterAccessory } from 'homebridge';
+import type { KseniaDevice } from '../types';
+import { PLUGIN_NAME, PLATFORM_NAME } from '../settings';
+import type { KseniaWebSocketClient } from '../websocket-client';
+import { deviceToMatterAccessory, toCentidegrees, clampCentidegrees, matterSystemModeToDomain } from './matter-device-mapper';
+
+export class MatterAccessoryRegistry {
+    private readonly cachedUUIDs: Set<string> = new Set();
+    private readonly registeredUUIDs: Set<string> = new Set();
+    private activeDiscoveredUUIDs: Set<string> = new Set();
+
+    constructor(
+        private readonly api: API,
+        private readonly log: Logger,
+        private readonly getWsClient: () => KseniaWebSocketClient | undefined,
+    ) {}
+
+    public get isEnabled(): boolean {
+        return !!this.api.matter;
+    }
+
+    public configureCachedAccessory(accessory: MatterAccessory): void {
+        this.cachedUUIDs.add(accessory.UUID);
+        this.log.debug(`[Matter] Cached accessory: ${accessory.displayName} (${accessory.UUID})`);
+    }
+
+    public startDiscoveryCycle(): void {
+        this.activeDiscoveredUUIDs = new Set();
+    }
+
+    public async addOrUpdateAccessory(device: KseniaDevice): Promise<void> {
+        if (!this.api.matter) return;
+
+        const matterAccessory = deviceToMatterAccessory(device, {
+            api: this.api,
+            log: this.log,
+            getWsClient: this.getWsClient,
+        });
+
+        if (!matterAccessory) {
+            return;
+        }
+
+        this.activeDiscoveredUUIDs.add(device.id);
+
+        if (this.registeredUUIDs.has(device.id)) {
+            // Already registered — update state
+            await this.pushStateUpdate(device);
+            return;
+        }
+
+        if (this.cachedUUIDs.has(device.id)) {
+            // Known from cache — re-register with fresh state (handles handler re-attachment)
+            this.log.debug(`[Matter] Restoring cached accessory: ${device.name}`);
+        } else {
+            this.log.info(`[Matter] Registering new accessory: ${device.name} (${device.type})`);
+        }
+
+        try {
+            await this.api.matter.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [matterAccessory]);
+            this.registeredUUIDs.add(device.id);
+            this.log.info(`[Matter] Registered: ${device.name}`);
+        } catch (err) {
+            this.log.warn(`[Matter] Failed to register ${device.name}: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+
+    public async updateAccessoryState(device: KseniaDevice): Promise<void> {
+        if (!this.api.matter) return;
+        if (!this.registeredUUIDs.has(device.id)) return;
+        await this.pushStateUpdate(device);
+    }
+
+    public async pruneStaleAccessories(): Promise<void> {
+        if (!this.api.matter) return;
+
+        for (const uuid of this.registeredUUIDs) {
+            if (!this.activeDiscoveredUUIDs.has(uuid)) {
+                this.log.info(`[Matter] Removing stale accessory: ${uuid}`);
+                try {
+                    await this.api.matter.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [
+                        { UUID: uuid } as MatterAccessory,
+                    ]);
+                    this.registeredUUIDs.delete(uuid);
+                    this.cachedUUIDs.delete(uuid);
+                } catch (err) {
+                    this.log.warn(`[Matter] Failed to unregister ${uuid}: ${err instanceof Error ? err.message : String(err)}`);
+                }
+            }
+        }
+    }
+
+    private async pushStateUpdate(device: KseniaDevice): Promise<void> {
+        const matter = this.api.matter!;
+        const uuid = device.id;
+
+        try {
+            switch (device.type) {
+                case 'light':
+                    await matter.updateAccessoryState(uuid, 'onOff', { onOff: device.status.on });
+                    if (device.status.dimmable && device.status.brightness !== undefined) {
+                        await matter.updateAccessoryState(uuid, 'levelControl', {
+                            currentLevel: Math.round((device.status.brightness / 100) * 254),
+                        });
+                    }
+                    break;
+
+                case 'cover': {
+                    const matterPos = Math.round((100 - (device.status.position ?? 0)) * 100);
+                    await matter.updateAccessoryState(uuid, 'windowCovering', {
+                        currentPositionLiftPercent100ths: matterPos,
+                        targetPositionLiftPercent100ths: matterPos,
+                    });
+                    break;
+                }
+
+                case 'thermostat': {
+                    const current = device.currentTemperature ?? 21;
+                    const target = device.targetTemperature ?? 21;
+                    await matter.updateAccessoryState(uuid, 'thermostat', {
+                        localTemperature: clampCentidegrees(toCentidegrees(current)),
+                        occupiedHeatingSetpoint: toCentidegrees(target),
+                        occupiedCoolingSetpoint: toCentidegrees(target),
+                        systemMode: domainModeToMatterMode(device.mode),
+                    });
+                    break;
+                }
+
+                case 'sensor': {
+                    const val = device.status.value;
+                    switch (device.status.sensorType) {
+                        case 'temperature':
+                            await matter.updateAccessoryState(uuid, 'temperatureMeasurement', {
+                                measuredValue: clampCentidegrees(toCentidegrees(val)),
+                            });
+                            break;
+                        case 'humidity':
+                            await matter.updateAccessoryState(uuid, 'relativeHumidityMeasurement', {
+                                measuredValue: Math.round(Math.max(0, Math.min(100, val)) * 100),
+                            });
+                            break;
+                        case 'motion':
+                            await matter.updateAccessoryState(uuid, 'occupancySensing', {
+                                occupancy: { occupied: val > 0 },
+                            });
+                            break;
+                        case 'contact':
+                            await matter.updateAccessoryState(uuid, 'booleanState', {
+                                stateValue: val === 0,
+                            });
+                            break;
+                    }
+                    break;
+                }
+
+                case 'zone':
+                    await matter.updateAccessoryState(uuid, 'booleanState', {
+                        stateValue: !device.status.open,
+                    });
+                    break;
+
+                case 'scenario':
+                    await matter.updateAccessoryState(uuid, 'onOff', {
+                        onOff: device.status.active,
+                    });
+                    break;
+
+                case 'gate':
+                    await matter.updateAccessoryState(uuid, 'onOff', {
+                        onOff: device.status.on,
+                    });
+                    break;
+            }
+        } catch (err) {
+            this.log.debug(`[Matter] State update error for ${uuid}: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+}
+
+// Matter Thermostat systemMode values
+function domainModeToMatterMode(mode: 'off' | 'heat' | 'cool' | 'auto'): number {
+    switch (mode) {
+        case 'heat': return 4;
+        case 'cool': return 3;
+        case 'auto': return 1;
+        default: return 0;
+    }
+}

--- a/src/platform/matter-accessory-registry.ts
+++ b/src/platform/matter-accessory-registry.ts
@@ -38,6 +38,7 @@ interface MatterRegistration {
     uuid: string;
     displayName: string;
     deviceType: string; // Lares4 device type, used for fallback decisions
+    matterAccessory: MatterAccessory;
     status: MatterRegistrationStatus;
     registeredAt?: number;
     failedAt?: number;
@@ -95,6 +96,7 @@ export class MatterAccessoryRegistry {
                     this.enqueueStateFor(device);
                     return;
                 case 'registered':
+                    await this.refreshAccessoryMetadata(device, existing);
                     await this.pushStateUpdate(device);
                     return;
                 case 'failed':
@@ -175,6 +177,7 @@ export class MatterAccessoryRegistry {
             uuid: device.id,
             displayName: device.name,
             deviceType: device.type,
+            matterAccessory,
             status: 'pending',
             pendingStateUpdates: [],
         };
@@ -203,6 +206,7 @@ export class MatterAccessoryRegistry {
         reg.status = 'registered';
         reg.registeredAt = Date.now();
         this.log.info(`[Matter] registered: ${reg.displayName}`);
+        await this.updateCachedAccessoryMetadata(reg);
 
         if (reg.pendingStateUpdates.length === 0) return;
 
@@ -238,6 +242,7 @@ export class MatterAccessoryRegistry {
             try {
                 await this.api.matter!.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [fallback]);
                 this.thermostatFallbackUUIDs.add(device.id);
+                reg.matterAccessory = fallback;
                 this.log.debug(`[Matter] settle started (${MATTER_REGISTER_SETTLE_MS}ms): ${device.name} [fallback]`);
                 setTimeout(() => { void this.completeRegistration(device.id); }, MATTER_REGISTER_SETTLE_MS);
                 return;
@@ -281,6 +286,38 @@ export class MatterAccessoryRegistry {
             else reg.pendingStateUpdates.push(u);
         }
         this.log.debug(`[Matter] update queued: ${device.name} (pending=${reg.pendingStateUpdates.length})`);
+    }
+
+    private async refreshAccessoryMetadata(device: KseniaDevice, reg: MatterRegistration): Promise<void> {
+        const matterAccessory = deviceToMatterAccessory(device, {
+            api: this.api,
+            log: this.log,
+            getWsClient: this.getWsClient,
+        });
+        if (!matterAccessory) return;
+
+        if (!this.hasMetadataChanged(reg.matterAccessory, matterAccessory)) return;
+
+        reg.matterAccessory = matterAccessory;
+        reg.displayName = matterAccessory.displayName;
+        await this.updateCachedAccessoryMetadata(reg);
+    }
+
+    private hasMetadataChanged(previous: MatterAccessory, next: MatterAccessory): boolean {
+        return previous.displayName !== next.displayName
+            || previous.manufacturer !== next.manufacturer
+            || previous.model !== next.model
+            || previous.serialNumber !== next.serialNumber
+            || previous.firmwareRevision !== next.firmwareRevision;
+    }
+
+    private async updateCachedAccessoryMetadata(reg: MatterRegistration): Promise<void> {
+        try {
+            await this.api.matter!.updatePlatformAccessories([reg.matterAccessory]);
+            this.log.debug(`[Matter] metadata cache refreshed: ${reg.displayName}`);
+        } catch (err) {
+            this.log.debug(`[Matter] metadata cache refresh failed for ${reg.displayName}: ${this.fmtErr(err)}`);
+        }
     }
 
     private buildUpdatesFor(device: KseniaDevice): PendingMatterStateUpdate[] {

--- a/src/platform/matter-accessory-registry.ts
+++ b/src/platform/matter-accessory-registry.ts
@@ -3,7 +3,7 @@ import type { MatterAccessory } from 'homebridge';
 import type { KseniaDevice } from '../types';
 import { PLUGIN_NAME, PLATFORM_NAME } from '../settings';
 import type { KseniaWebSocketClient } from '../websocket-client';
-import { deviceToMatterAccessory, toCentidegrees, clampCentidegrees } from './matter-device-mapper';
+import { deviceToMatterAccessory, toCentidegrees, clampCentidegrees, domainModeToMatterMode } from './matter-device-mapper';
 
 export class MatterAccessoryRegistry {
     private readonly cachedUUIDs: Set<string> = new Set();
@@ -118,11 +118,16 @@ export class MatterAccessoryRegistry {
                 case 'thermostat': {
                     const current = device.currentTemperature ?? 21;
                     const target = device.targetTemperature ?? 21;
+                    const mode = device.mode ?? 'heat';
+                    const HEAT_MIN = 700;
+                    const HEAT_MAX = 3000;
+                    // HeatingOnly profile: only Off/Heat are valid SystemMode values to keep coherence
+                    // with controlSequenceOfOperation=HeatingOnly set at registration time.
+                    const safeMode = mode === 'off' ? 'off' : 'heat';
                     await matter.updateAccessoryState(uuid, 'thermostat', {
                         localTemperature: clampCentidegrees(toCentidegrees(current)),
-                        occupiedHeatingSetpoint: toCentidegrees(target),
-                        occupiedCoolingSetpoint: toCentidegrees(target),
-                        systemMode: domainModeToMatterMode(device.mode),
+                        occupiedHeatingSetpoint: Math.max(HEAT_MIN, Math.min(HEAT_MAX, toCentidegrees(target))),
+                        systemMode: domainModeToMatterMode(safeMode),
                     });
                     break;
                 }
@@ -138,6 +143,11 @@ export class MatterAccessoryRegistry {
                         case 'humidity':
                             await matter.updateAccessoryState(uuid, 'relativeHumidityMeasurement', {
                                 measuredValue: Math.round(Math.max(0, Math.min(100, val)) * 100),
+                            });
+                            break;
+                        case 'light':
+                            await matter.updateAccessoryState(uuid, 'illuminanceMeasurement', {
+                                measuredValue: val <= 0 ? 0 : Math.max(1, Math.min(65534, Math.round(10000 * Math.log10(val) + 1))),
                             });
                             break;
                         case 'motion':
@@ -178,12 +188,3 @@ export class MatterAccessoryRegistry {
     }
 }
 
-// Matter Thermostat systemMode values
-function domainModeToMatterMode(mode: 'off' | 'heat' | 'cool' | 'auto'): number {
-    switch (mode) {
-        case 'heat': return 4;
-        case 'cool': return 3;
-        case 'auto': return 1;
-        default: return 0;
-    }
-}

--- a/src/platform/matter-accessory-registry.ts
+++ b/src/platform/matter-accessory-registry.ts
@@ -8,6 +8,11 @@ import { deviceToMatterAccessory, toCentidegrees, clampCentidegrees, domainModeT
 export class MatterAccessoryRegistry {
     private readonly cachedUUIDs: Set<string> = new Set();
     private readonly registeredUUIDs: Set<string> = new Set();
+    private readonly failedUUIDs: Set<string> = new Set();
+    // Tracks when each UUID was registered — state updates are deferred until the IPC commit
+    // has had time to complete (HB2 registerPlatformAccessories is fire-and-forget on the API side).
+    private readonly registeredAt: Map<string, number> = new Map();
+    private static readonly REGISTER_SETTLE_MS = 2000;
     private activeDiscoveredUUIDs: Set<string> = new Set();
 
     constructor(
@@ -31,6 +36,9 @@ export class MatterAccessoryRegistry {
 
     public async addOrUpdateAccessory(device: KseniaDevice): Promise<void> {
         if (!this.api.matter) return;
+        // Skip devices whose registration has previously failed — retrying floods logs with
+        // identical Behavior errors and never recovers within a single process lifetime.
+        if (this.failedUUIDs.has(device.id)) return;
 
         const matterAccessory = deviceToMatterAccessory(device, {
             api: this.api,
@@ -45,36 +53,50 @@ export class MatterAccessoryRegistry {
         this.activeDiscoveredUUIDs.add(device.id);
 
         if (this.registeredUUIDs.has(device.id)) {
-            // Already registered — update state
-            await this.pushStateUpdate(device);
+            // Already registered — push state, but only if past the IPC settle window.
+            const registeredAt = this.registeredAt.get(device.id) ?? 0;
+            if (Date.now() - registeredAt >= MatterAccessoryRegistry.REGISTER_SETTLE_MS) {
+                await this.pushStateUpdate(device);
+            }
             return;
         }
 
-        if (this.cachedUUIDs.has(device.id)) {
-            // Already restored from cache by HB2 — handlers re-attached. Just track and push state.
-            this.log.debug(`[Matter] Restored from cache: ${device.name}`);
-            this.registeredUUIDs.add(device.id);
-            await this.pushStateUpdate(device);
-            return;
+        const fromCache = this.cachedUUIDs.has(device.id);
+        if (fromCache) {
+            this.log.debug(`[Matter] Restoring cached accessory: ${device.name}`);
+        } else {
+            this.log.info(`[Matter] Registering new accessory: ${device.name} (${device.type})`);
         }
 
-        this.log.info(`[Matter] Registering new accessory: ${device.name} (${device.type})`);
         try {
             await this.api.matter.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [matterAccessory]);
             this.registeredUUIDs.add(device.id);
+            this.registeredAt.set(device.id, Date.now());
             this.log.info(`[Matter] Registered: ${device.name}`);
+            // Do NOT push state immediately — registerPlatformAccessories is fire-and-forget on the
+            // API side (emits an event, doesn't await commit). The initial clusters payload in the
+            // MatterAccessory already carries the current state, so the next status update will
+            // catch up after REGISTER_SETTLE_MS.
         } catch (err) {
-            this.log.warn(`[Matter] Failed to register ${device.name}: ${err instanceof Error ? err.message : String(err)}`);
+            this.failedUUIDs.add(device.id);
+            this.log.warn(`[Matter] Failed to register ${device.name} — will not retry this session: ${err instanceof Error ? err.message : String(err)}`);
         }
     }
 
     public async updateAccessoryState(device: KseniaDevice): Promise<void> {
         if (!this.api.matter) return;
+        // Skip devices that we've already failed to register — avoids log spam.
+        if (this.failedUUIDs.has(device.id)) return;
         // Lazy registration: an HAP status update can arrive before the WS "discovered" callback,
-        // especially for accessories already in HAP cache. Register on the fly so we don't miss
-        // any device. Both paths use addOrUpdateAccessory which is idempotent (registeredUUIDs gate).
+        // especially for accessories already in HAP cache. Register on the fly so we don't miss any.
         if (!this.registeredUUIDs.has(device.id)) {
             await this.addOrUpdateAccessory(device);
+            return;
+        }
+        // Skip state pushes during the IPC settle window — the registration event hasn't been
+        // processed by the Matter server yet, so updateAccessoryState would fail with "not found".
+        const registeredAt = this.registeredAt.get(device.id) ?? 0;
+        if (Date.now() - registeredAt < MatterAccessoryRegistry.REGISTER_SETTLE_MS) {
             return;
         }
         await this.pushStateUpdate(device);

--- a/src/platform/matter-accessory-registry.ts
+++ b/src/platform/matter-accessory-registry.ts
@@ -213,7 +213,6 @@ export class MatterAccessoryRegistry {
         reg.registeredAt = Date.now();
         this.stateUpdateQueue.markReadyAfterBootstrap(reg);
         this.log.info(`[Matter] registered: ${reg.displayName}`);
-        await this.updateCachedAccessoryMetadata(reg);
 
         this.stateUpdateQueue.scheduleFlush(uuid);
     }
@@ -287,7 +286,6 @@ export class MatterAccessoryRegistry {
 
         reg.matterAccessory = matterAccessory;
         reg.displayName = matterAccessory.displayName;
-        await this.updateCachedAccessoryMetadata(reg);
     }
 
     private hasMetadataChanged(previous: MatterAccessory, next: MatterAccessory): boolean {
@@ -296,15 +294,6 @@ export class MatterAccessoryRegistry {
             || previous.model !== next.model
             || previous.serialNumber !== next.serialNumber
             || previous.firmwareRevision !== next.firmwareRevision;
-    }
-
-    private async updateCachedAccessoryMetadata(reg: MatterRegistration): Promise<void> {
-        try {
-            await this.api.matter!.updatePlatformAccessories([reg.matterAccessory]);
-            this.log.debug(`[Matter] metadata cache refreshed: ${reg.displayName}`);
-        } catch (err) {
-            this.log.debug(`[Matter] metadata cache refresh failed for ${reg.displayName}: ${this.fmtErr(err)}`);
-        }
     }
 
     private buildUpdatesFor(device: KseniaDevice): PendingMatterStateUpdate[] {

--- a/src/platform/matter-accessory-registry.ts
+++ b/src/platform/matter-accessory-registry.ts
@@ -70,7 +70,13 @@ export class MatterAccessoryRegistry {
 
     public async updateAccessoryState(device: KseniaDevice): Promise<void> {
         if (!this.api.matter) return;
-        if (!this.registeredUUIDs.has(device.id)) return;
+        // Lazy registration: an HAP status update can arrive before the WS "discovered" callback,
+        // especially for accessories already in HAP cache. Register on the fly so we don't miss
+        // any device. Both paths use addOrUpdateAccessory which is idempotent (registeredUUIDs gate).
+        if (!this.registeredUUIDs.has(device.id)) {
+            await this.addOrUpdateAccessory(device);
+            return;
+        }
         await this.pushStateUpdate(device);
     }
 
@@ -121,15 +127,18 @@ export class MatterAccessoryRegistry {
                     const current = device.currentTemperature ?? 21;
                     const target = device.targetTemperature ?? 21;
                     const mode = device.mode ?? 'heat';
-                    const HEAT_MIN = 700;
-                    const HEAT_MAX = 3000;
-                    // HeatingOnly profile: only Off/Heat are valid SystemMode values to keep coherence
-                    // with controlSequenceOfOperation=HeatingOnly set at registration time.
-                    const safeMode = mode === 'off' ? 'off' : 'heat';
+                    const HEAT_MIN = 700, HEAT_MAX = 3000;
+                    const COOL_MIN = 1600, COOL_MAX = 3200;
+                    const DEADBAND_CENTI = 250;
+                    const heatingSetpoint = Math.max(HEAT_MIN, Math.min(HEAT_MAX, toCentidegrees(target)));
+                    const coolingSetpoint = Math.max(COOL_MIN, Math.min(COOL_MAX, heatingSetpoint + DEADBAND_CENTI));
                     await matter.updateAccessoryState(uuid, 'thermostat', {
                         localTemperature: clampCentidegrees(toCentidegrees(current)),
-                        occupiedHeatingSetpoint: Math.max(HEAT_MIN, Math.min(HEAT_MAX, toCentidegrees(target))),
-                        systemMode: domainModeToMatterMode(safeMode),
+                        occupiedHeatingSetpoint: heatingSetpoint,
+                        occupiedCoolingSetpoint: coolingSetpoint,
+                        unoccupiedHeatingSetpoint: heatingSetpoint,
+                        unoccupiedCoolingSetpoint: coolingSetpoint,
+                        systemMode: domainModeToMatterMode(mode),
                     });
                     break;
                 }

--- a/src/platform/matter-accessory-registry.ts
+++ b/src/platform/matter-accessory-registry.ts
@@ -211,10 +211,11 @@ export class MatterAccessoryRegistry {
 
         reg.status = 'registered';
         reg.registeredAt = Date.now();
+        this.stateUpdateQueue.markReadyAfterBootstrap(reg);
         this.log.info(`[Matter] registered: ${reg.displayName}`);
         await this.updateCachedAccessoryMetadata(reg);
 
-        this.stateUpdateQueue.scheduleFlush(uuid, 0);
+        this.stateUpdateQueue.scheduleFlush(uuid);
     }
 
     /**

--- a/src/platform/matter-accessory-registry.ts
+++ b/src/platform/matter-accessory-registry.ts
@@ -3,61 +3,53 @@ import type { MatterAccessory } from 'homebridge';
 import type { KseniaDevice, KseniaThermostat } from '../types';
 import { PLUGIN_NAME, PLATFORM_NAME } from '../settings';
 import type { KseniaWebSocketClient } from '../websocket-client';
-import { deviceToMatterAccessory } from './matter-device-mapper';
-import { buildStateUpdates, type PendingMatterStateUpdate } from './matter-state-updates';
+import { deviceToMatterAccessory, mapThermostatAsTemperatureSensor } from './matter-device-mapper';
+import { buildStateUpdates } from './matter-state-updates';
 import {
     handleMissingRegisteredAccessory,
-    isMatterAccessoryQueryable,
     registerFallbackAccessory,
     type MatterRegistration,
 } from './matter-registration-recovery';
 import { MatterStateUpdateQueue } from './matter-state-update-queue';
-
-// ---------------------------------------------------------------------------
-// Configuration knobs
-// ---------------------------------------------------------------------------
-
-/**
- * Time to wait between calling `api.matter.registerPlatformAccessories(...)` and
- * trusting that the accessory is queryable via `api.matter.updateAccessoryState(...)`.
- * HB2's register API is fire-and-forget (it just emits an internal event); state
- * updates received in this window are buffered.
- */
-const MATTER_REGISTER_SETTLE_MS = 2000;
+import { MatterFallbackStore } from './matter-fallback-store';
+import { probeUntilQueryable } from './matter-register-probe';
 
 /**
  * Whether to fall back to a Matter TemperatureSensor when registering a real
  * Thermostat fails (typically due to matter.js 0.17 `presetTypes` validation).
- * HAP continues to expose the full Thermostat regardless.
  */
 const MATTER_THERMOSTAT_FALLBACK_TO_TEMPERATURE_SENSOR = true;
 
-// ---------------------------------------------------------------------------
-// Registration state machine
-// ---------------------------------------------------------------------------
-
 export type MatterRegistrationStatus = 'pending' | 'registered' | 'failed' | 'skipped';
 
-// ---------------------------------------------------------------------------
-// Registry
-// ---------------------------------------------------------------------------
+export interface MatterRegistryDeps {
+    api: API;
+    log: Logger;
+    getWsClient: () => KseniaWebSocketClient | undefined;
+    storagePath: string;
+    momentaryAutoOffMs?: number;
+}
 
 export class MatterAccessoryRegistry {
-    /** UUIDs that HB2 reported to us via `configureMatterAccessory` (cache restore). */
+    private readonly api: API;
+    private readonly log: Logger;
+    private readonly getWsClient: () => KseniaWebSocketClient | undefined;
+    private readonly momentaryAutoOffMs?: number;
     private readonly cachedUUIDs: Set<string> = new Set();
-    /** Full registration state, keyed by Lares device id (also the Matter UUID). */
     private readonly registrations: Map<string, MatterRegistration> = new Map();
     private readonly stateUpdateQueue: MatterStateUpdateQueue;
-    /** UUIDs we've seen in the current discovery cycle — used to prune stale ones. */
     private activeDiscoveredUUIDs: Set<string> = new Set();
-    /** UUIDs that fell back to TemperatureSensor — drive the alternate state-push path. */
     private readonly thermostatFallbackUUIDs: Set<string> = new Set();
+    private readonly fallbackStore: MatterFallbackStore;
 
-    constructor(
-        private readonly api: API,
-        private readonly log: Logger,
-        private readonly getWsClient: () => KseniaWebSocketClient | undefined,
-    ) {
+    constructor(deps: MatterRegistryDeps) {
+        this.api = deps.api;
+        this.log = deps.log;
+        this.getWsClient = deps.getWsClient;
+        this.momentaryAutoOffMs = deps.momentaryAutoOffMs;
+        this.fallbackStore = new MatterFallbackStore(deps.storagePath, deps.log);
+        for (const uuid of this.fallbackStore.load()) this.thermostatFallbackUUIDs.add(uuid);
+
         this.stateUpdateQueue = new MatterStateUpdateQueue(
             this.api,
             this.log,
@@ -69,10 +61,6 @@ export class MatterAccessoryRegistry {
     public get isEnabled(): boolean {
         return !!this.api.matter;
     }
-
-    // -----------------------------------------------------------------------
-    // Lifecycle hooks called by Platform
-    // -----------------------------------------------------------------------
 
     public configureCachedAccessory(accessory: MatterAccessory): void {
         this.cachedUUIDs.add(accessory.UUID);
@@ -89,19 +77,18 @@ export class MatterAccessoryRegistry {
 
         const existing = this.registrations.get(device.id);
         if (existing) {
-            // Already known — either still pending the settle window, registered, failed or skipped.
             switch (existing.status) {
                 case 'pending':
-                    // Queue the latest state; the settle handler will flush it.
                     this.enqueueStateFor(device);
                     return;
                 case 'registered':
                     await this.refreshAccessoryMetadata(device, existing);
-                    await this.pushStateUpdate(device);
+                    this.enqueueStateFor(device);
+                    this.stateUpdateQueue.scheduleFlush(device.id);
                     return;
                 case 'failed':
                 case 'skipped':
-                    return; // silent, we've already logged once
+                    return;
             }
         }
 
@@ -111,25 +98,13 @@ export class MatterAccessoryRegistry {
     public async updateAccessoryState(device: KseniaDevice): Promise<void> {
         if (!this.api.matter) return;
         const existing = this.registrations.get(device.id);
-
         if (!existing) {
-            // First time we see this device — register it (lazy path for HAP-cached devices
-            // whose WS "discovered" callback hasn't fired yet).
             await this.registerAccessory(device);
             return;
         }
-
-        switch (existing.status) {
-            case 'pending':
-                this.enqueueStateFor(device);
-                return;
-            case 'registered':
-                await this.pushStateUpdate(device);
-                return;
-            case 'failed':
-            case 'skipped':
-                return;
-        }
+        if (existing.status === 'failed' || existing.status === 'skipped') return;
+        this.enqueueStateFor(device);
+        this.stateUpdateQueue.scheduleFlush(device.id);
     }
 
     public async pruneStaleAccessories(): Promise<void> {
@@ -145,32 +120,35 @@ export class MatterAccessoryRegistry {
                 this.registrations.delete(uuid);
                 this.cachedUUIDs.delete(uuid);
                 this.thermostatFallbackUUIDs.delete(uuid);
+                this.fallbackStore.remove(uuid);
             } catch (err) {
                 this.log.warn(`[Matter] Failed to unregister ${uuid}: ${this.fmtErr(err)}`);
             }
         }
     }
 
-    /** Test-only introspection: registration status for a given device id. */
     public getStatus(uuid: string): MatterRegistrationStatus | undefined {
         return this.registrations.get(uuid)?.status;
     }
 
-    /** Test-only introspection: queued updates count for a device id. */
     public getPendingCount(uuid: string): number {
         return this.registrations.get(uuid)?.pendingStateUpdates.length ?? 0;
     }
 
-    // -----------------------------------------------------------------------
-    // Registration internals
-    // -----------------------------------------------------------------------
-
-    private async registerAccessory(device: KseniaDevice): Promise<void> {
-        const matterAccessory = deviceToMatterAccessory(device, {
+    private mapperDeps() {
+        return {
             api: this.api,
             log: this.log,
             getWsClient: this.getWsClient,
-        });
+            momentaryAutoOffMs: this.momentaryAutoOffMs,
+        };
+    }
+
+    private async registerAccessory(device: KseniaDevice): Promise<void> {
+        const persistedFallback = device.type === 'thermostat' && this.thermostatFallbackUUIDs.has(device.id);
+        const matterAccessory = persistedFallback
+            ? mapThermostatAsTemperatureSensor(device as KseniaThermostat, this.mapperDeps())
+            : deviceToMatterAccessory(device, this.mapperDeps());
         if (!matterAccessory) return;
 
         const reg: MatterRegistration = {
@@ -180,55 +158,72 @@ export class MatterAccessoryRegistry {
             matterAccessory,
             status: 'pending',
             recoveryAttempts: 0,
-            pendingStateUpdates: [],
+            pendingStateUpdates: buildStateUpdates(device, persistedFallback),
         };
         this.registrations.set(device.id, reg);
 
         const fromCache = this.cachedUUIDs.has(device.id);
-        this.log.info(`[Matter] register requested: ${device.name} (${device.type})${fromCache ? ' [cache restore]' : ''}`);
+        if (fromCache) {
+            this.log.info(`[Matter] resumed from cache: ${device.name} (${device.type})${persistedFallback ? ' [fallback]' : ''}`);
+            // The Matter storage already holds the endpoint — skip register, just probe.
+            void this.completeRegistration(device.id, /*skipRegister=*/ true);
+            return;
+        }
 
+        this.log.info(`[Matter] register requested: ${device.name} (${device.type})${persistedFallback ? ' [fallback]' : ''}`);
         try {
             await this.api.matter!.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [matterAccessory]);
         } catch (err) {
             await this.handleRegisterFailure(device, err);
             return;
         }
-
-        this.log.debug(`[Matter] settle started (${MATTER_REGISTER_SETTLE_MS}ms): ${device.name}`);
-        // Don't `await` the settle timer — let the WS event loop continue. Queued updates
-        // are stored on the registration; we flush them when the timer fires.
-        this.scheduleComplete(device.id);
+        void this.completeRegistration(device.id);
     }
 
-    private async completeRegistration(uuid: string): Promise<void> {
+    private async completeRegistration(uuid: string, skipRegister = false): Promise<void> {
         const reg = this.registrations.get(uuid);
         if (!reg || reg.status !== 'pending') return;
 
-        if (!await isMatterAccessoryQueryable(this.api, this.log, (err) => this.fmtErr(err), reg)) {
+        const queryable = await probeUntilQueryable(this.api, this.log, (e) => this.fmtErr(e), reg);
+        if (!queryable) {
+            if (skipRegister) {
+                // Cache resume failed — endpoint was lost from storage. Fall back to full register.
+                this.log.warn(`[Matter] cache resume probe timed out for ${reg.displayName}; re-registering.`);
+                try {
+                    await this.api.matter!.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [reg.matterAccessory]);
+                    void this.completeRegistration(uuid);
+                } catch (err) {
+                    await this.handleRegisterFailure(reg.matterAccessory.context.device as KseniaDevice, err);
+                }
+                return;
+            }
             await handleMissingRegisteredAccessory(reg, this.recoveryDeps());
             return;
         }
 
         reg.status = 'registered';
         reg.registeredAt = Date.now();
+        // After successful register as real Thermostat, drop any stale fallback marker.
+        if (reg.deviceType === 'thermostat' && !this.isFallbackAccessory(reg)) {
+            if (this.thermostatFallbackUUIDs.delete(uuid)) this.fallbackStore.remove(uuid);
+        }
         this.stateUpdateQueue.markReadyAfterBootstrap(reg);
         this.log.info(`[Matter] registered: ${reg.displayName}`);
-
         this.stateUpdateQueue.scheduleFlush(uuid);
     }
 
-    /**
-     * Centralised handler for failed initial registration. Currently only used for thermostats —
-     * other device types are simply marked failed and skipped for the session.
-     */
+    private isFallbackAccessory(reg: MatterRegistration): boolean {
+        const clusters = reg.matterAccessory.clusters ?? {};
+        return 'temperatureMeasurement' in clusters && !('thermostat' in clusters);
+    }
+
     private async handleRegisterFailure(device: KseniaDevice, err: unknown): Promise<void> {
         const reg = this.registrations.get(device.id)!;
         const msg = this.fmtErr(err);
 
         if (device.type === 'thermostat' && MATTER_THERMOSTAT_FALLBACK_TO_TEMPERATURE_SENSOR) {
             this.log.warn(
-                `Matter Thermostat registration failed for ${device.name}; falling back to TemperatureSensor `
-                + `due to matter.js thermostat presetTypes validation issue. Error: ${msg}`,
+                `Matter Thermostat registration failed for ${device.name}; falling back to TemperatureSensor. Error: ${msg}`,
             );
             try {
                 await registerFallbackAccessory(device as KseniaThermostat, reg, this.recoveryDeps());
@@ -245,45 +240,27 @@ export class MatterAccessoryRegistry {
         this.log.warn(`[Matter] accessory failed: ${device.name} — ${msg}`);
     }
 
-    // -----------------------------------------------------------------------
-    // State propagation
-    // -----------------------------------------------------------------------
-
-    private async pushStateUpdate(device: KseniaDevice): Promise<void> {
-        const reg = this.registrations.get(device.id);
-        if (!reg) return;
-
-        const updates = this.buildUpdatesFor(device);
-        for (const u of updates) {
-            await this.stateUpdateQueue.pushOrQueue(reg, u);
-        }
-    }
-
     private enqueueStateFor(device: KseniaDevice): void {
         const reg = this.registrations.get(device.id);
         if (!reg) return;
         reg.matterAccessory.context.device = device;
-        for (const u of this.buildUpdatesFor(device)) {
-            // Dedupe by (clusterName, partId) — keep only the latest payload per slot.
+        const fallback = device.type === 'thermostat' && this.thermostatFallbackUUIDs.has(device.id);
+        for (const u of buildStateUpdates(device, fallback)) {
             const idx = reg.pendingStateUpdates.findIndex(
                 (p) => p.clusterName === u.clusterName && p.partId === u.partId,
             );
             if (idx >= 0) reg.pendingStateUpdates[idx] = u;
             else reg.pendingStateUpdates.push(u);
         }
-        this.log.debug(`[Matter] update queued: ${device.name} (pending=${reg.pendingStateUpdates.length})`);
     }
 
     private async refreshAccessoryMetadata(device: KseniaDevice, reg: MatterRegistration): Promise<void> {
-        const matterAccessory = deviceToMatterAccessory(device, {
-            api: this.api,
-            log: this.log,
-            getWsClient: this.getWsClient,
-        });
+        const fallback = device.type === 'thermostat' && this.thermostatFallbackUUIDs.has(device.id);
+        const matterAccessory = fallback
+            ? mapThermostatAsTemperatureSensor(device as KseniaThermostat, this.mapperDeps())
+            : deviceToMatterAccessory(device, this.mapperDeps());
         if (!matterAccessory) return;
-
         if (!this.hasMetadataChanged(reg.matterAccessory, matterAccessory)) return;
-
         reg.matterAccessory = matterAccessory;
         reg.displayName = matterAccessory.displayName;
     }
@@ -296,17 +273,8 @@ export class MatterAccessoryRegistry {
             || previous.firmwareRevision !== next.firmwareRevision;
     }
 
-    private buildUpdatesFor(device: KseniaDevice): PendingMatterStateUpdate[] {
-        const isFallback = device.type === 'thermostat' && this.thermostatFallbackUUIDs.has(device.id);
-        return buildStateUpdates(device, isFallback);
-    }
-
     private fmtErr(err: unknown): string {
         return err instanceof Error ? err.message : String(err);
-    }
-
-    private scheduleComplete(uuid: string): void {
-        setTimeout(() => { void this.completeRegistration(uuid); }, MATTER_REGISTER_SETTLE_MS);
     }
 
     private recoveryDeps(): Parameters<typeof handleMissingRegisteredAccessory>[1] {
@@ -315,10 +283,11 @@ export class MatterAccessoryRegistry {
             log: this.log,
             thermostatFallbackUUIDs: this.thermostatFallbackUUIDs,
             getWsClient: this.getWsClient,
-            scheduleComplete: (uuid) => this.scheduleComplete(uuid),
+            scheduleComplete: (uuid) => { void this.completeRegistration(uuid); },
             fmtErr: (err) => this.fmtErr(err),
-            settleMs: MATTER_REGISTER_SETTLE_MS,
             thermostatFallbackEnabled: MATTER_THERMOSTAT_FALLBACK_TO_TEMPERATURE_SENSOR,
+            momentaryAutoOffMs: this.momentaryAutoOffMs,
+            onFallbackPersist: (uuid) => this.fallbackStore.add(uuid),
         };
     }
 }

--- a/src/platform/matter-accessory-registry.ts
+++ b/src/platform/matter-accessory-registry.ts
@@ -3,7 +3,7 @@ import type { MatterAccessory } from 'homebridge';
 import type { KseniaDevice } from '../types';
 import { PLUGIN_NAME, PLATFORM_NAME } from '../settings';
 import type { KseniaWebSocketClient } from '../websocket-client';
-import { deviceToMatterAccessory, toCentidegrees, clampCentidegrees, matterSystemModeToDomain } from './matter-device-mapper';
+import { deviceToMatterAccessory, toCentidegrees, clampCentidegrees } from './matter-device-mapper';
 
 export class MatterAccessoryRegistry {
     private readonly cachedUUIDs: Set<string> = new Set();

--- a/src/platform/matter-device-mapper.ts
+++ b/src/platform/matter-device-mapper.ts
@@ -1,0 +1,303 @@
+import type { API, Logger } from 'homebridge';
+import type { MatterAccessory } from 'homebridge';
+import type {
+    KseniaCover,
+    KseniaDevice,
+    KseniaGate,
+    KseniaLight,
+    KseniaScenario,
+    KseniaSensor,
+    KseniaThermostat,
+    KseniaZone,
+} from '../types';
+import { PLUGIN_NAME } from '../settings';
+import { PLUGIN_VERSION } from '../plugin-version';
+import type { KseniaWebSocketClient } from '../websocket-client';
+
+// Matter Thermostat systemMode values (Matter spec 1.3 §4.3.7.22)
+const THERMOSTAT_MODE_OFF = 0;
+const THERMOSTAT_MODE_AUTO = 1;
+const THERMOSTAT_MODE_COOL = 3;
+const THERMOSTAT_MODE_HEAT = 4;
+
+// Matter Thermostat controlSequenceOfOperation: 4 = Heating And Cooling
+const THERMOSTAT_CONTROL_SEQ_HEAT_COOL = 4;
+
+function domainModeToMatter(mode: 'off' | 'heat' | 'cool' | 'auto'): number {
+    switch (mode) {
+        case 'heat': return THERMOSTAT_MODE_HEAT;
+        case 'cool': return THERMOSTAT_MODE_COOL;
+        case 'auto': return THERMOSTAT_MODE_AUTO;
+        default: return THERMOSTAT_MODE_OFF;
+    }
+}
+
+function matterModeToDomain(systemMode: number): 'off' | 'heat' | 'cool' | 'auto' {
+    switch (systemMode) {
+        case THERMOSTAT_MODE_HEAT: return 'heat';
+        case THERMOSTAT_MODE_COOL: return 'cool';
+        case THERMOSTAT_MODE_AUTO: return 'auto';
+        default: return 'off';
+    }
+}
+
+// Matter temperatures are in centidegrees (°C * 100)
+function toCentidegrees(celsius: number): number {
+    return Math.round(celsius * 100);
+}
+
+function clampCentidegrees(val: number): number {
+    return Math.max(-27000, Math.min(10000, val));
+}
+
+interface MapperDeps {
+    api: API;
+    log: Logger;
+    getWsClient: () => KseniaWebSocketClient | undefined;
+}
+
+function baseFields(device: KseniaDevice): Pick<MatterAccessory, 'UUID' | 'displayName' | 'serialNumber' | 'manufacturer' | 'model' | 'firmwareRevision' | 'context'> {
+    return {
+        UUID: device.id,
+        displayName: device.name,
+        serialNumber: device.id,
+        manufacturer: 'Ksenia',
+        model: `Lares4 ${device.type}`,
+        firmwareRevision: PLUGIN_VERSION,
+        context: { device },
+    };
+}
+
+function mapLight(device: KseniaLight, deps: MapperDeps): MatterAccessory {
+    const { api, log, getWsClient } = deps;
+    const isDimmable = device.status?.dimmable ?? false;
+    const onOff = device.status?.on ?? false;
+    const level = device.status?.brightness ?? (onOff ? 100 : 0);
+
+    const clusters: MatterAccessory['clusters'] = isDimmable
+        ? {
+            onOff: { onOff },
+            levelControl: { currentLevel: Math.round((level / 100) * 254), minLevel: 1, maxLevel: 254 },
+        }
+        : { onOff: { onOff } };
+
+    const handlers: MatterAccessory['handlers'] = {
+        onOff: {
+            on: async () => {
+                await getWsClient()?.switchLight(device.id, true);
+            },
+            off: async () => {
+                await getWsClient()?.switchLight(device.id, false);
+            },
+        },
+    };
+
+    if (isDimmable) {
+        handlers.levelControl = {
+            moveToLevel: async (args: { level: number }) => {
+                const pct = Math.round((args.level / 254) * 100);
+                await getWsClient()?.dimLight(device.id, pct);
+            },
+            moveToLevelWithOnOff: async (args: { level: number }) => {
+                const pct = Math.round((args.level / 254) * 100);
+                await getWsClient()?.dimLight(device.id, pct);
+            },
+        };
+    }
+
+    return {
+        ...baseFields(device),
+        deviceType: isDimmable
+            ? api.matter!.deviceTypes.DimmableLight
+            : api.matter!.deviceTypes.OnOffLight,
+        clusters,
+        handlers,
+    };
+}
+
+function mapCover(device: KseniaCover, deps: MapperDeps): MatterAccessory {
+    const { api, log, getWsClient } = deps;
+    const pos = device.status?.position ?? 0;
+    // Matter WindowCovering position is in percent * 100 (0–10000), and 0 = fully open, 10000 = fully closed
+    // Lares4 position: 0 = closed, 100 = open — invert for Matter
+    const matterPos = Math.round((100 - pos) * 100);
+
+    return {
+        ...baseFields(device),
+        deviceType: api.matter!.deviceTypes.WindowCovering,
+        clusters: {
+            windowCovering: {
+                currentPositionLiftPercent100ths: matterPos,
+                targetPositionLiftPercent100ths: matterPos,
+                configStatus: { liftPositionAware: true, operational: true },
+            },
+        },
+        handlers: {
+            windowCovering: {
+                goToLiftPercentage: async (args: { liftPercent100thsValue: number }) => {
+                    // Matter 0=open 10000=closed → Lares4 0=closed 100=open
+                    const targetPct = 100 - Math.round(args.liftPercent100thsValue / 100);
+                    await getWsClient()?.moveCover(device.id, targetPct);
+                },
+            },
+        },
+    };
+}
+
+function mapThermostat(device: KseniaThermostat, deps: MapperDeps): MatterAccessory {
+    const { api, log, getWsClient } = deps;
+    const currentTemp = device.currentTemperature ?? 21;
+    const targetTemp = device.targetTemperature ?? 21;
+
+    return {
+        ...baseFields(device),
+        deviceType: api.matter!.deviceTypes.Thermostat,
+        clusters: {
+            thermostat: {
+                localTemperature: clampCentidegrees(toCentidegrees(currentTemp)),
+                occupiedHeatingSetpoint: toCentidegrees(targetTemp),
+                occupiedCoolingSetpoint: toCentidegrees(targetTemp),
+                systemMode: domainModeToMatter(device.mode),
+                controlSequenceOfOperation: THERMOSTAT_CONTROL_SEQ_HEAT_COOL,
+            },
+        },
+        handlers: {
+            thermostat: {
+                setpointRaiseLower: async (args: { mode: number; amount: number }) => {
+                    const newTarget = targetTemp + args.amount / 10;
+                    await getWsClient()?.setThermostatTemperature(device.id, newTarget);
+                },
+            },
+        },
+    };
+}
+
+function mapSensor(device: KseniaSensor, deps: MapperDeps): MatterAccessory | undefined {
+    const { api } = deps;
+    const val = device.status.value;
+
+    switch (device.status.sensorType) {
+        case 'temperature':
+            return {
+                ...baseFields(device),
+                deviceType: api.matter!.deviceTypes.TemperatureSensor,
+                clusters: {
+                    temperatureMeasurement: {
+                        measuredValue: clampCentidegrees(toCentidegrees(val)),
+                    },
+                },
+            };
+        case 'humidity':
+            return {
+                ...baseFields(device),
+                deviceType: api.matter!.deviceTypes.HumiditySensor,
+                clusters: {
+                    relativeHumidityMeasurement: {
+                        measuredValue: Math.round(Math.max(0, Math.min(100, val)) * 100),
+                    },
+                },
+            };
+        case 'motion':
+            return {
+                ...baseFields(device),
+                deviceType: api.matter!.deviceTypes.MotionSensor,
+                clusters: {
+                    occupancySensing: {
+                        occupancy: { occupied: val > 0 },
+                    },
+                },
+            };
+        case 'contact':
+            return {
+                ...baseFields(device),
+                deviceType: api.matter!.deviceTypes.ContactSensor,
+                clusters: {
+                    booleanState: { stateValue: val === 0 }, // true = contact detected (closed)
+                },
+            };
+        default:
+            return undefined;
+    }
+}
+
+function mapZone(device: KseniaZone, deps: MapperDeps): MatterAccessory {
+    const { api } = deps;
+    // Zone: open = intrusione rilevata (stateValue false = alarm)
+    const contactClosed = !device.status.open;
+    return {
+        ...baseFields(device),
+        deviceType: api.matter!.deviceTypes.ContactSensor,
+        clusters: {
+            booleanState: { stateValue: contactClosed },
+        },
+    };
+}
+
+function mapScenario(device: KseniaScenario, deps: MapperDeps): MatterAccessory {
+    const { api, getWsClient } = deps;
+    return {
+        ...baseFields(device),
+        deviceType: api.matter!.deviceTypes.OnOffSwitch,
+        clusters: {
+            onOff: { onOff: device.status.active },
+        },
+        handlers: {
+            onOff: {
+                on: async () => {
+                    await getWsClient()?.triggerScenario(device.id);
+                },
+                off: async () => {
+                    // Scenarios are stateless triggers; no deactivation command
+                },
+            },
+        },
+    };
+}
+
+function mapGate(device: KseniaGate, deps: MapperDeps): MatterAccessory {
+    const { api, getWsClient } = deps;
+    return {
+        ...baseFields(device),
+        deviceType: api.matter!.deviceTypes.OnOffOutlet,
+        clusters: {
+            onOff: { onOff: device.status.on },
+        },
+        handlers: {
+            onOff: {
+                on: async () => {
+                    await getWsClient()?.toggleGate(device.id);
+                },
+                off: async () => {
+                    await getWsClient()?.toggleGate(device.id);
+                },
+            },
+        },
+    };
+}
+
+export function deviceToMatterAccessory(device: KseniaDevice, deps: MapperDeps): MatterAccessory | undefined {
+    if (!deps.api.matter) {
+        return undefined;
+    }
+    try {
+        switch (device.type) {
+            case 'light': return mapLight(device, deps);
+            case 'cover': return mapCover(device, deps);
+            case 'thermostat': return mapThermostat(device, deps);
+            case 'sensor': return mapSensor(device, deps);
+            case 'zone': return mapZone(device, deps);
+            case 'scenario': return mapScenario(device, deps);
+            case 'gate': return mapGate(device, deps);
+            default: return undefined;
+        }
+    } catch (err) {
+        deps.log.warn(`Matter mapper error for ${(device as KseniaDevice).name}: ${err instanceof Error ? err.message : String(err)}`);
+        return undefined;
+    }
+}
+
+export function matterSystemModeToDomain(systemMode: number): 'off' | 'heat' | 'cool' | 'auto' {
+    return matterModeToDomain(systemMode);
+}
+
+export { toCentidegrees, clampCentidegrees };

--- a/src/platform/matter-device-mapper.ts
+++ b/src/platform/matter-device-mapper.ts
@@ -13,40 +13,30 @@ import type {
 import { PLUGIN_VERSION } from '../plugin-version';
 import type { KseniaWebSocketClient } from '../websocket-client';
 
-// Matter Thermostat systemMode values (Matter spec 1.3 §4.3.7.22)
-const THERMOSTAT_MODE_OFF = 0;
-const THERMOSTAT_MODE_AUTO = 1;
-const THERMOSTAT_MODE_COOL = 3;
-const THERMOSTAT_MODE_HEAT = 4;
-
-// Matter Thermostat controlSequenceOfOperation: 4 = Heating And Cooling
-const THERMOSTAT_CONTROL_SEQ_HEAT_COOL = 4;
-
-function domainModeToMatter(mode: 'off' | 'heat' | 'cool' | 'auto'): number {
-    switch (mode) {
-        case 'heat': return THERMOSTAT_MODE_HEAT;
-        case 'cool': return THERMOSTAT_MODE_COOL;
-        case 'auto': return THERMOSTAT_MODE_AUTO;
-        default: return THERMOSTAT_MODE_OFF;
-    }
-}
-
-function matterModeToDomain(systemMode: number): 'off' | 'heat' | 'cool' | 'auto' {
-    switch (systemMode) {
-        case THERMOSTAT_MODE_HEAT: return 'heat';
-        case THERMOSTAT_MODE_COOL: return 'cool';
-        case THERMOSTAT_MODE_AUTO: return 'auto';
-        default: return 'off';
-    }
-}
-
 // Matter temperatures are in centidegrees (°C * 100)
-function toCentidegrees(celsius: number): number {
+export function toCentidegrees(celsius: number): number {
     return Math.round(celsius * 100);
 }
 
-function clampCentidegrees(val: number): number {
+export function clampCentidegrees(val: number): number {
     return Math.max(-27000, Math.min(10000, val));
+}
+
+// Matter Thermostat systemMode values (Matter spec 1.3 §4.3.7.22)
+// 0=Off, 1=Auto, 3=Cool, 4=Heat
+export function domainModeToMatterMode(mode: 'off' | 'heat' | 'cool' | 'auto'): number {
+    switch (mode) {
+        case 'heat': return 4;
+        case 'cool': return 3;
+        case 'auto': return 1;
+        default:     return 0;
+    }
+}
+
+// Matter illuminance: measuredValue = 10000 * log10(lux) + 1  (spec §2.2.5.1)
+function luxToMatterIlluminance(lux: number): number {
+    if (lux <= 0) return 0;
+    return Math.max(1, Math.min(65534, Math.round(10000 * Math.log10(lux) + 1)));
 }
 
 interface MapperDeps {
@@ -71,23 +61,21 @@ function mapLight(device: KseniaLight, deps: MapperDeps): MatterAccessory {
     const { api, getWsClient } = deps;
     const isDimmable = device.status?.dimmable ?? false;
     const onOff = device.status?.on ?? false;
-    const level = device.status?.brightness ?? (onOff ? 100 : 0);
+    const brightness = device.status?.brightness ?? (onOff ? 100 : 0);
+    // Matter LevelControl: range 1–254. Level 0 is forbidden even when off — OnOff cluster owns on/off state.
+    const currentLevel = Math.max(1, Math.round((brightness / 100) * 254));
 
     const clusters: MatterAccessory['clusters'] = isDimmable
         ? {
             onOff: { onOff },
-            levelControl: { currentLevel: Math.round((level / 100) * 254), minLevel: 1, maxLevel: 254 },
+            levelControl: { currentLevel, minLevel: 1, maxLevel: 254 },
         }
         : { onOff: { onOff } };
 
     const handlers: MatterAccessory['handlers'] = {
         onOff: {
-            on: async () => {
-                await getWsClient()?.switchLight(device.id, true);
-            },
-            off: async () => {
-                await getWsClient()?.switchLight(device.id, false);
-            },
+            on: async () => { await getWsClient()?.switchLight(device.id, true); },
+            off: async () => { await getWsClient()?.switchLight(device.id, false); },
         },
     };
 
@@ -117,8 +105,7 @@ function mapLight(device: KseniaLight, deps: MapperDeps): MatterAccessory {
 function mapCover(device: KseniaCover, deps: MapperDeps): MatterAccessory {
     const { api, getWsClient } = deps;
     const pos = device.status?.position ?? 0;
-    // Matter WindowCovering position is in percent * 100 (0–10000), and 0 = fully open, 10000 = fully closed
-    // Lares4 position: 0 = closed, 100 = open — invert for Matter
+    // Lares4: 0=closed, 100=open. Matter: 0=open (0%), 10000=closed (100%).
     const matterPos = Math.round((100 - pos) * 100);
 
     return {
@@ -147,23 +134,44 @@ function mapThermostat(device: KseniaThermostat, deps: MapperDeps): MatterAccess
     const { api, getWsClient } = deps;
     const currentTemp = device.currentTemperature ?? 21;
     const targetTemp = device.targetTemperature ?? 21;
+    const mode = device.mode ?? 'heat';
+
+    // Matter Thermostat HEAT-feature-only profile (safe default for Lares4 heating zones).
+    // ControlSequenceOfOperationEnum.HeatingOnly = 0x02 (Matter spec §4.3.7.30, NOT 0 which is CoolingOnly).
+    // SystemModeEnum: Off=0x00, Heat=0x04 (Auto requires AUTO feature + minSetpointDeadBand → avoid here).
+    // HEAT range defaults: AbsMinHeatSetpointLimit=700 (7°C), AbsMaxHeatSetpointLimit=3000 (30°C).
+    const HEAT_MIN = 700;
+    const HEAT_MAX = 3000;
+    const TEMP_ABS_MIN = -27000;
+    const TEMP_ABS_MAX = 10000;
+    const CONTROL_SEQ_HEATING_ONLY = 2;
+
+    const heatingSetpoint = Math.max(HEAT_MIN, Math.min(HEAT_MAX, toCentidegrees(targetTemp)));
+    const localTemp = Math.max(TEMP_ABS_MIN, Math.min(TEMP_ABS_MAX, toCentidegrees(currentTemp)));
+    // For HeatingOnly profile, valid SystemMode values are Off (0) or Heat (4) — collapse cool/auto to Heat
+    // so a stale Lares4 mode doesn't violate the cluster's mode/control coherence.
+    const safeMode = (mode === 'off') ? 'off' : 'heat';
 
     return {
         ...baseFields(device),
         deviceType: api.matter!.deviceTypes.Thermostat,
         clusters: {
             thermostat: {
-                localTemperature: clampCentidegrees(toCentidegrees(currentTemp)),
-                occupiedHeatingSetpoint: toCentidegrees(targetTemp),
-                occupiedCoolingSetpoint: toCentidegrees(targetTemp),
-                systemMode: domainModeToMatter(device.mode),
-                controlSequenceOfOperation: THERMOSTAT_CONTROL_SEQ_HEAT_COOL,
+                localTemperature: localTemp,
+                occupiedHeatingSetpoint: heatingSetpoint,
+                absMinHeatSetpointLimit: HEAT_MIN,
+                absMaxHeatSetpointLimit: HEAT_MAX,
+                minHeatSetpointLimit: HEAT_MIN,
+                maxHeatSetpointLimit: HEAT_MAX,
+                controlSequenceOfOperation: CONTROL_SEQ_HEATING_ONLY,
+                systemMode: domainModeToMatterMode(safeMode),
             },
         },
         handlers: {
             thermostat: {
                 setpointRaiseLower: async (args: { mode: number; amount: number }) => {
-                    const newTarget = targetTemp + args.amount / 10;
+                    const delta = args.amount / 10;
+                    const newTarget = (device.targetTemperature ?? 21) + delta;
                     await getWsClient()?.setThermostatTemperature(device.id, newTarget);
                 },
             },
@@ -196,6 +204,17 @@ function mapSensor(device: KseniaSensor, deps: MapperDeps): MatterAccessory | un
                     },
                 },
             };
+        case 'light': {
+            return {
+                ...baseFields(device),
+                deviceType: api.matter!.deviceTypes.LightSensor,
+                clusters: {
+                    illuminanceMeasurement: {
+                        measuredValue: luxToMatterIlluminance(val),
+                    },
+                },
+            };
+        }
         case 'motion':
             return {
                 ...baseFields(device),
@@ -221,13 +240,11 @@ function mapSensor(device: KseniaSensor, deps: MapperDeps): MatterAccessory | un
 
 function mapZone(device: KseniaZone, deps: MapperDeps): MatterAccessory {
     const { api } = deps;
-    // Zone: open = intrusione rilevata (stateValue false = alarm)
-    const contactClosed = !device.status.open;
     return {
         ...baseFields(device),
         deviceType: api.matter!.deviceTypes.ContactSensor,
         clusters: {
-            booleanState: { stateValue: contactClosed },
+            booleanState: { stateValue: !device.status.open }, // open=true → alarm → stateValue=false
         },
     };
 }
@@ -242,12 +259,8 @@ function mapScenario(device: KseniaScenario, deps: MapperDeps): MatterAccessory 
         },
         handlers: {
             onOff: {
-                on: async () => {
-                    await getWsClient()?.triggerScenario(device.id);
-                },
-                off: async () => {
-                    // Scenarios are stateless triggers; no deactivation command
-                },
+                on: async () => { await getWsClient()?.triggerScenario(device.id); },
+                off: async () => { /* stateless trigger — no deactivation */ },
             },
         },
     };
@@ -263,12 +276,8 @@ function mapGate(device: KseniaGate, deps: MapperDeps): MatterAccessory {
         },
         handlers: {
             onOff: {
-                on: async () => {
-                    await getWsClient()?.toggleGate(device.id);
-                },
-                off: async () => {
-                    await getWsClient()?.toggleGate(device.id);
-                },
+                on: async () => { await getWsClient()?.toggleGate(device.id); },
+                off: async () => { await getWsClient()?.toggleGate(device.id); },
             },
         },
     };
@@ -280,23 +289,17 @@ export function deviceToMatterAccessory(device: KseniaDevice, deps: MapperDeps):
     }
     try {
         switch (device.type) {
-            case 'light': return mapLight(device, deps);
-            case 'cover': return mapCover(device, deps);
+            case 'light':      return mapLight(device, deps);
+            case 'cover':      return mapCover(device, deps);
             case 'thermostat': return mapThermostat(device, deps);
-            case 'sensor': return mapSensor(device, deps);
-            case 'zone': return mapZone(device, deps);
-            case 'scenario': return mapScenario(device, deps);
-            case 'gate': return mapGate(device, deps);
-            default: return undefined;
+            case 'sensor':     return mapSensor(device, deps);
+            case 'zone':       return mapZone(device, deps);
+            case 'scenario':   return mapScenario(device, deps);
+            case 'gate':       return mapGate(device, deps);
+            default:           return undefined;
         }
     } catch (err) {
-        deps.log.warn(`Matter mapper error for ${(device as KseniaDevice).name}: ${err instanceof Error ? err.message : String(err)}`);
+        deps.log.warn(`[Matter] Mapper error for ${(device as KseniaDevice).name}: ${err instanceof Error ? err.message : String(err)}`);
         return undefined;
     }
 }
-
-export function matterSystemModeToDomain(systemMode: number): 'off' | 'heat' | 'cool' | 'auto' {
-    return matterModeToDomain(systemMode);
-}
-
-export { toCentidegrees, clampCentidegrees };

--- a/src/platform/matter-device-mapper.ts
+++ b/src/platform/matter-device-mapper.ts
@@ -1,4 +1,4 @@
-import type { API, Logger } from 'homebridge';
+import type { API } from 'homebridge';
 import type { MatterAccessory } from 'homebridge';
 import type {
     KseniaCover,
@@ -10,7 +10,6 @@ import type {
     KseniaThermostat,
     KseniaZone,
 } from '../types';
-import { PLUGIN_NAME } from '../settings';
 import { PLUGIN_VERSION } from '../plugin-version';
 import type { KseniaWebSocketClient } from '../websocket-client';
 
@@ -52,7 +51,7 @@ function clampCentidegrees(val: number): number {
 
 interface MapperDeps {
     api: API;
-    log: Logger;
+    log: import('homebridge').Logger;
     getWsClient: () => KseniaWebSocketClient | undefined;
 }
 
@@ -69,7 +68,7 @@ function baseFields(device: KseniaDevice): Pick<MatterAccessory, 'UUID' | 'displ
 }
 
 function mapLight(device: KseniaLight, deps: MapperDeps): MatterAccessory {
-    const { api, log, getWsClient } = deps;
+    const { api, getWsClient } = deps;
     const isDimmable = device.status?.dimmable ?? false;
     const onOff = device.status?.on ?? false;
     const level = device.status?.brightness ?? (onOff ? 100 : 0);
@@ -116,7 +115,7 @@ function mapLight(device: KseniaLight, deps: MapperDeps): MatterAccessory {
 }
 
 function mapCover(device: KseniaCover, deps: MapperDeps): MatterAccessory {
-    const { api, log, getWsClient } = deps;
+    const { api, getWsClient } = deps;
     const pos = device.status?.position ?? 0;
     // Matter WindowCovering position is in percent * 100 (0–10000), and 0 = fully open, 10000 = fully closed
     // Lares4 position: 0 = closed, 100 = open — invert for Matter
@@ -145,7 +144,7 @@ function mapCover(device: KseniaCover, deps: MapperDeps): MatterAccessory {
 }
 
 function mapThermostat(device: KseniaThermostat, deps: MapperDeps): MatterAccessory {
-    const { api, log, getWsClient } = deps;
+    const { api, getWsClient } = deps;
     const currentTemp = device.currentTemperature ?? 21;
     const targetTemp = device.targetTemperature ?? 21;
 

--- a/src/platform/matter-device-mapper.ts
+++ b/src/platform/matter-device-mapper.ts
@@ -12,18 +12,16 @@ import type {
 } from '../types';
 import { PLUGIN_VERSION } from '../plugin-version';
 import type { KseniaWebSocketClient } from '../websocket-client';
+import { buildThermostatMatterState, toMatterTemperatureCelsius, clampMatterTemperature, TEMP_ABS_MIN_CENTI, TEMP_ABS_MAX_CENTI } from './matter-thermostat-mapper';
 
-// Matter temperatures are in centidegrees (°C * 100)
-export function toCentidegrees(celsius: number): number {
-    return Math.round(celsius * 100);
-}
-
+// Re-exports for legacy callers (registry pushStateUpdate, tests)
+export { toMatterTemperatureCelsius as toCentidegrees };
+export { buildThermostatMatterState };
 export function clampCentidegrees(val: number): number {
-    return Math.max(-27000, Math.min(10000, val));
+    return clampMatterTemperature(val, TEMP_ABS_MIN_CENTI, TEMP_ABS_MAX_CENTI);
 }
 
-// Matter Thermostat systemMode values (Matter spec 1.3 §4.3.7.22)
-// 0=Off, 1=Auto, 3=Cool, 4=Heat
+// Matter Thermostat systemMode values (Matter spec 1.3 §4.3.7.32): 0=Off, 1=Auto, 3=Cool, 4=Heat
 export function domainModeToMatterMode(mode: 'off' | 'heat' | 'cool' | 'auto'): number {
     switch (mode) {
         case 'heat': return 4;
@@ -33,9 +31,10 @@ export function domainModeToMatterMode(mode: 'off' | 'heat' | 'cool' | 'auto'): 
     }
 }
 
-// Matter illuminance: measuredValue = 10000 * log10(lux) + 1  (spec §2.2.5.1)
-function luxToMatterIlluminance(lux: number): number {
-    if (lux <= 0) return 0;
+// Matter illuminance: measuredValue = 10000 * log10(lux) + 1  (Matter spec §2.2.5.1).
+// Returns 0 for lux <= 0 (the spec uses 0 to mean "below the sensor's range").
+export function luxToMatterIlluminance(lux: number): number {
+    if (!Number.isFinite(lux) || lux <= 0) return 0;
     return Math.max(1, Math.min(65534, Math.round(10000 * Math.log10(lux) + 1)));
 }
 
@@ -121,7 +120,6 @@ function mapCover(device: KseniaCover, deps: MapperDeps): MatterAccessory {
         handlers: {
             windowCovering: {
                 goToLiftPercentage: async (args: { liftPercent100thsValue: number }) => {
-                    // Matter 0=open 10000=closed → Lares4 0=closed 100=open
                     const targetPct = 100 - Math.round(args.liftPercent100thsValue / 100);
                     await getWsClient()?.moveCover(device.id, targetPct);
                 },
@@ -132,60 +130,13 @@ function mapCover(device: KseniaCover, deps: MapperDeps): MatterAccessory {
 
 function mapThermostat(device: KseniaThermostat, deps: MapperDeps): MatterAccessory {
     const { api, getWsClient } = deps;
-    const currentTemp = device.currentTemperature ?? 21;
-    const targetTemp = device.targetTemperature ?? 21;
-    const mode = device.mode ?? 'heat';
-
-    // Homebridge 2's bundled Thermostat device type enables HEAT + COOL + AUTO + OCC features
-    // (heating:true, cooling:true, autoMode:true, occupancy:true). All mandatory attributes for these
-    // features must be supplied. matter.js 0.17 additionally enforces presetTypes length ≥1 (even
-    // though presets:false) — provide a single Occupied placeholder. Matter spec §4.3.7/4.3.8.
-    const HEAT_MIN = 700;   // 7°C
-    const HEAT_MAX = 3000;  // 30°C
-    const COOL_MIN = 1600;  // 16°C
-    const COOL_MAX = 3200;  // 32°C
-    const DEADBAND_CENTI = 250;  // 2.5°C in centidegrees
-    const TEMP_ABS_MIN = -27000;
-    const TEMP_ABS_MAX = 10000;
-    const CONTROL_SEQ_COOLING_AND_HEATING = 4;
-
-    const heatingSetpoint = Math.max(HEAT_MIN, Math.min(HEAT_MAX, toCentidegrees(targetTemp)));
-    // Cooling setpoint must be ≥ heating + deadband to satisfy the AUTO-mode invariant.
-    const coolingSetpoint = Math.max(COOL_MIN, Math.min(COOL_MAX, heatingSetpoint + DEADBAND_CENTI));
-    const localTemp = Math.max(TEMP_ABS_MIN, Math.min(TEMP_ABS_MAX, toCentidegrees(currentTemp)));
+    const { base, schemaInvariants } = buildThermostatMatterState(device);
 
     return {
         ...baseFields(device),
         deviceType: api.matter!.deviceTypes.Thermostat,
         clusters: {
-            thermostat: {
-                localTemperature: localTemp,
-                // HEAT feature mandatory attrs
-                occupiedHeatingSetpoint: heatingSetpoint,
-                absMinHeatSetpointLimit: HEAT_MIN,
-                absMaxHeatSetpointLimit: HEAT_MAX,
-                minHeatSetpointLimit: HEAT_MIN,
-                maxHeatSetpointLimit: HEAT_MAX,
-                // COOL feature mandatory attrs
-                occupiedCoolingSetpoint: coolingSetpoint,
-                absMinCoolSetpointLimit: COOL_MIN,
-                absMaxCoolSetpointLimit: COOL_MAX,
-                minCoolSetpointLimit: COOL_MIN,
-                maxCoolSetpointLimit: COOL_MAX,
-                // AUTO feature mandatory attr (deadband is int8s in tenths of °C → 25 = 2.5°C)
-                minSetpointDeadBand: DEADBAND_CENTI / 10,
-                // OCC feature mandatory attrs
-                unoccupiedHeatingSetpoint: heatingSetpoint,
-                unoccupiedCoolingSetpoint: coolingSetpoint,
-                // Always mandatory
-                controlSequenceOfOperation: CONTROL_SEQ_COOLING_AND_HEATING,
-                systemMode: domainModeToMatterMode(mode),
-                // matter.js 0.17 quirk: presetTypes array must have length 1..7 even with PRES feature off.
-                // PresetScenarioEnum.Occupied = 1 (spec §4.3.8.16).
-                presetTypes: [{ presetScenario: 1, numberOfPresets: 1, presetTypeFeatures: 0 }],
-                numberOfPresets: 1,
-                // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-            } as Record<string, unknown>,
+            thermostat: { ...base, ...schemaInvariants } as Record<string, unknown>,
         },
         handlers: {
             thermostat: {
@@ -194,6 +145,25 @@ function mapThermostat(device: KseniaThermostat, deps: MapperDeps): MatterAccess
                     const newTarget = (device.targetTemperature ?? 21) + delta;
                     await getWsClient()?.setThermostatTemperature(device.id, newTarget);
                 },
+            },
+        },
+    };
+}
+
+/**
+ * Fallback mapping: register a thermostat as a Matter TemperatureSensor.
+ * Used only when the regular Thermostat registration fails upstream (matter.js bug).
+ * HAP continues to expose the full Thermostat — Matter loses write control but keeps read.
+ */
+export function mapThermostatAsTemperatureSensor(device: KseniaThermostat, deps: MapperDeps): MatterAccessory {
+    const { api } = deps;
+    const currentC = device.currentTemperature ?? 21;
+    return {
+        ...baseFields(device),
+        deviceType: api.matter!.deviceTypes.TemperatureSensor,
+        clusters: {
+            temperatureMeasurement: {
+                measuredValue: clampCentidegrees(toMatterTemperatureCelsius(currentC)),
             },
         },
     };
@@ -210,7 +180,7 @@ function mapSensor(device: KseniaSensor, deps: MapperDeps): MatterAccessory | un
                 deviceType: api.matter!.deviceTypes.TemperatureSensor,
                 clusters: {
                     temperatureMeasurement: {
-                        measuredValue: clampCentidegrees(toCentidegrees(val)),
+                        measuredValue: clampCentidegrees(toMatterTemperatureCelsius(val)),
                     },
                 },
             };
@@ -224,25 +194,20 @@ function mapSensor(device: KseniaSensor, deps: MapperDeps): MatterAccessory | un
                     },
                 },
             };
-        case 'light': {
+        case 'light':
             return {
                 ...baseFields(device),
                 deviceType: api.matter!.deviceTypes.LightSensor,
                 clusters: {
-                    illuminanceMeasurement: {
-                        measuredValue: luxToMatterIlluminance(val),
-                    },
+                    illuminanceMeasurement: { measuredValue: luxToMatterIlluminance(val) },
                 },
             };
-        }
         case 'motion':
             return {
                 ...baseFields(device),
                 deviceType: api.matter!.deviceTypes.MotionSensor,
                 clusters: {
-                    occupancySensing: {
-                        occupancy: { occupied: val > 0 },
-                    },
+                    occupancySensing: { occupancy: { occupied: val > 0 } },
                 },
             };
         case 'contact':

--- a/src/platform/matter-device-mapper.ts
+++ b/src/platform/matter-device-mapper.ts
@@ -136,21 +136,23 @@ function mapThermostat(device: KseniaThermostat, deps: MapperDeps): MatterAccess
     const targetTemp = device.targetTemperature ?? 21;
     const mode = device.mode ?? 'heat';
 
-    // Matter Thermostat HEAT-feature-only profile (safe default for Lares4 heating zones).
-    // ControlSequenceOfOperationEnum.HeatingOnly = 0x02 (Matter spec §4.3.7.30, NOT 0 which is CoolingOnly).
-    // SystemModeEnum: Off=0x00, Heat=0x04 (Auto requires AUTO feature + minSetpointDeadBand → avoid here).
-    // HEAT range defaults: AbsMinHeatSetpointLimit=700 (7°C), AbsMaxHeatSetpointLimit=3000 (30°C).
-    const HEAT_MIN = 700;
-    const HEAT_MAX = 3000;
+    // Homebridge 2's bundled Thermostat device type enables HEAT + COOL + AUTO + OCC features
+    // (heating:true, cooling:true, autoMode:true, occupancy:true). All mandatory attributes for these
+    // features must be supplied. matter.js 0.17 additionally enforces presetTypes length ≥1 (even
+    // though presets:false) — provide a single Occupied placeholder. Matter spec §4.3.7/4.3.8.
+    const HEAT_MIN = 700;   // 7°C
+    const HEAT_MAX = 3000;  // 30°C
+    const COOL_MIN = 1600;  // 16°C
+    const COOL_MAX = 3200;  // 32°C
+    const DEADBAND_CENTI = 250;  // 2.5°C in centidegrees
     const TEMP_ABS_MIN = -27000;
     const TEMP_ABS_MAX = 10000;
-    const CONTROL_SEQ_HEATING_ONLY = 2;
+    const CONTROL_SEQ_COOLING_AND_HEATING = 4;
 
     const heatingSetpoint = Math.max(HEAT_MIN, Math.min(HEAT_MAX, toCentidegrees(targetTemp)));
+    // Cooling setpoint must be ≥ heating + deadband to satisfy the AUTO-mode invariant.
+    const coolingSetpoint = Math.max(COOL_MIN, Math.min(COOL_MAX, heatingSetpoint + DEADBAND_CENTI));
     const localTemp = Math.max(TEMP_ABS_MIN, Math.min(TEMP_ABS_MAX, toCentidegrees(currentTemp)));
-    // For HeatingOnly profile, valid SystemMode values are Off (0) or Heat (4) — collapse cool/auto to Heat
-    // so a stale Lares4 mode doesn't violate the cluster's mode/control coherence.
-    const safeMode = (mode === 'off') ? 'off' : 'heat';
 
     return {
         ...baseFields(device),
@@ -158,14 +160,32 @@ function mapThermostat(device: KseniaThermostat, deps: MapperDeps): MatterAccess
         clusters: {
             thermostat: {
                 localTemperature: localTemp,
+                // HEAT feature mandatory attrs
                 occupiedHeatingSetpoint: heatingSetpoint,
                 absMinHeatSetpointLimit: HEAT_MIN,
                 absMaxHeatSetpointLimit: HEAT_MAX,
                 minHeatSetpointLimit: HEAT_MIN,
                 maxHeatSetpointLimit: HEAT_MAX,
-                controlSequenceOfOperation: CONTROL_SEQ_HEATING_ONLY,
-                systemMode: domainModeToMatterMode(safeMode),
-            },
+                // COOL feature mandatory attrs
+                occupiedCoolingSetpoint: coolingSetpoint,
+                absMinCoolSetpointLimit: COOL_MIN,
+                absMaxCoolSetpointLimit: COOL_MAX,
+                minCoolSetpointLimit: COOL_MIN,
+                maxCoolSetpointLimit: COOL_MAX,
+                // AUTO feature mandatory attr (deadband is int8s in tenths of °C → 25 = 2.5°C)
+                minSetpointDeadBand: DEADBAND_CENTI / 10,
+                // OCC feature mandatory attrs
+                unoccupiedHeatingSetpoint: heatingSetpoint,
+                unoccupiedCoolingSetpoint: coolingSetpoint,
+                // Always mandatory
+                controlSequenceOfOperation: CONTROL_SEQ_COOLING_AND_HEATING,
+                systemMode: domainModeToMatterMode(mode),
+                // matter.js 0.17 quirk: presetTypes array must have length 1..7 even with PRES feature off.
+                // PresetScenarioEnum.Occupied = 1 (spec §4.3.8.16).
+                presetTypes: [{ presetScenario: 1, numberOfPresets: 1, presetTypeFeatures: 0 }],
+                numberOfPresets: 1,
+                // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+            } as Record<string, unknown>,
         },
         handlers: {
             thermostat: {
@@ -230,7 +250,7 @@ function mapSensor(device: KseniaSensor, deps: MapperDeps): MatterAccessory | un
                 ...baseFields(device),
                 deviceType: api.matter!.deviceTypes.ContactSensor,
                 clusters: {
-                    booleanState: { stateValue: val === 0 }, // true = contact detected (closed)
+                    booleanState: { stateValue: val === 0 },
                 },
             };
         default:
@@ -244,7 +264,7 @@ function mapZone(device: KseniaZone, deps: MapperDeps): MatterAccessory {
         ...baseFields(device),
         deviceType: api.matter!.deviceTypes.ContactSensor,
         clusters: {
-            booleanState: { stateValue: !device.status.open }, // open=true → alarm → stateValue=false
+            booleanState: { stateValue: !device.status.open },
         },
     };
 }
@@ -260,7 +280,7 @@ function mapScenario(device: KseniaScenario, deps: MapperDeps): MatterAccessory 
         handlers: {
             onOff: {
                 on: async () => { await getWsClient()?.triggerScenario(device.id); },
-                off: async () => { /* stateless trigger — no deactivation */ },
+                off: async () => { /* stateless trigger */ },
             },
         },
     };

--- a/src/platform/matter-device-mapper.ts
+++ b/src/platform/matter-device-mapper.ts
@@ -42,6 +42,20 @@ interface MapperDeps {
     api: API;
     log: import('homebridge').Logger;
     getWsClient: () => KseniaWebSocketClient | undefined;
+    /** Auto-off delay (ms) for momentary OnOff devices (scenarios, gates). Default 500ms. */
+    momentaryAutoOffMs?: number;
+}
+
+const DEFAULT_MOMENTARY_AUTO_OFF_MS = 500;
+
+function scheduleMomentaryAutoOff(uuid: string, deps: MapperDeps): void {
+    const delay = deps.momentaryAutoOffMs ?? DEFAULT_MOMENTARY_AUTO_OFF_MS;
+    setTimeout(() => {
+        deps.api.matter?.updateAccessoryState(uuid, 'onOff', { onOff: false })
+            .catch((err: unknown) => {
+                deps.log.debug(`[Matter] momentary auto-off failed for ${uuid}: ${err instanceof Error ? err.message : String(err)}`);
+            });
+    }, delay);
 }
 
 function baseFields(device: KseniaDevice): Pick<MatterAccessory, 'UUID' | 'displayName' | 'serialNumber' | 'manufacturer' | 'model' | 'firmwareRevision' | 'context'> {
@@ -240,12 +254,15 @@ function mapScenario(device: KseniaScenario, deps: MapperDeps): MatterAccessory 
         ...baseFields(device),
         deviceType: api.matter!.deviceTypes.OnOffSwitch,
         clusters: {
-            onOff: { onOff: device.status.active },
+            onOff: { onOff: false },
         },
         handlers: {
             onOff: {
-                on: async () => { await getWsClient()?.triggerScenario(device.id); },
-                off: async () => { /* stateless trigger */ },
+                on: async () => {
+                    await getWsClient()?.triggerScenario(device.id);
+                    scheduleMomentaryAutoOff(device.id, deps);
+                },
+                off: async () => { /* momentary trigger — no-op */ },
             },
         },
     };
@@ -255,14 +272,17 @@ function mapGate(device: KseniaGate, deps: MapperDeps): MatterAccessory {
     const { api, getWsClient } = deps;
     return {
         ...baseFields(device),
-        deviceType: api.matter!.deviceTypes.OnOffOutlet,
+        deviceType: api.matter!.deviceTypes.OnOffSwitch,
         clusters: {
-            onOff: { onOff: device.status.on },
+            onOff: { onOff: false },
         },
         handlers: {
             onOff: {
-                on: async () => { await getWsClient()?.toggleGate(device.id); },
-                off: async () => { await getWsClient()?.toggleGate(device.id); },
+                on: async () => {
+                    await getWsClient()?.toggleGate(device.id);
+                    scheduleMomentaryAutoOff(device.id, deps);
+                },
+                off: async () => { /* momentary trigger — no-op */ },
             },
         },
     };

--- a/src/platform/matter-fallback-store.ts
+++ b/src/platform/matter-fallback-store.ts
@@ -1,0 +1,75 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type { Logger } from 'homebridge';
+
+const STORE_FILENAME = 'klares4-matter-fallback.json';
+
+interface StoreShape {
+    thermostatAsTemperatureSensor: string[];
+}
+
+/**
+ * Persists the set of thermostat UUIDs that were registered as Matter
+ * TemperatureSensors (fallback path). Survives child-bridge restarts so the
+ * plugin and the Matter storage stay in sync — without this, after a restart
+ * the plugin would push to `thermostat` cluster on an endpoint that the Matter
+ * storage already committed as TemperatureSensor.
+ */
+export class MatterFallbackStore {
+    private readonly filePath: string;
+    private cache: Set<string> = new Set();
+    private loaded = false;
+
+    constructor(storagePath: string, private readonly log: Logger) {
+        this.filePath = path.join(storagePath, STORE_FILENAME);
+    }
+
+    public load(): Set<string> {
+        if (this.loaded) return this.cache;
+        this.loaded = true;
+        try {
+            if (!fs.existsSync(this.filePath)) {
+                this.cache = new Set();
+                return this.cache;
+            }
+            const raw = fs.readFileSync(this.filePath, 'utf8');
+            const parsed = JSON.parse(raw) as Partial<StoreShape>;
+            const arr = Array.isArray(parsed.thermostatAsTemperatureSensor)
+                ? parsed.thermostatAsTemperatureSensor.filter((x): x is string => typeof x === 'string')
+                : [];
+            this.cache = new Set(arr);
+        } catch (err) {
+            this.log.warn(`[Matter] Could not load fallback store (${this.filePath}): ${err instanceof Error ? err.message : String(err)}`);
+            this.cache = new Set();
+        }
+        return this.cache;
+    }
+
+    public add(uuid: string): void {
+        this.load();
+        if (this.cache.has(uuid)) return;
+        this.cache.add(uuid);
+        this.write();
+    }
+
+    public remove(uuid: string): void {
+        this.load();
+        if (!this.cache.has(uuid)) return;
+        this.cache.delete(uuid);
+        this.write();
+    }
+
+    public has(uuid: string): boolean {
+        this.load();
+        return this.cache.has(uuid);
+    }
+
+    private write(): void {
+        try {
+            const payload: StoreShape = { thermostatAsTemperatureSensor: [...this.cache].sort() };
+            fs.writeFileSync(this.filePath, JSON.stringify(payload, null, 2), 'utf8');
+        } catch (err) {
+            this.log.warn(`[Matter] Could not write fallback store (${this.filePath}): ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+}

--- a/src/platform/matter-register-probe.ts
+++ b/src/platform/matter-register-probe.ts
@@ -1,0 +1,62 @@
+import type { API, Logger } from 'homebridge';
+import type { MatterRegistration } from './matter-registration-recovery';
+import { isMatterAccessoryQueryable } from './matter-registration-recovery';
+
+/**
+ * Probe-based settle: poll `api.matter.getAccessoryState` after registration
+ * until the endpoint actually answers, then resolve. Replaces the legacy fixed
+ * 2-second `setTimeout` which caused early `updateAccessoryState` calls to
+ * fail with "Accessory not registered or missing endpoint".
+ *
+ * Backoff: 250ms → 500ms → 1000ms → 1000ms ... up to `timeoutMs` total.
+ * Returns `true` if the endpoint became queryable, `false` if the timeout
+ * elapsed first (caller decides recovery).
+ */
+const DEFAULT_TIMEOUT_MS = 10000;
+const DEFAULT_POLL_INITIAL_MS = 250;
+const DEFAULT_POLL_MAX_MS = 1000;
+
+export interface ProbeOptions {
+    timeoutMs?: number;
+    initialDelayMs?: number;
+    maxDelayMs?: number;
+}
+
+function envNumber(name: string, fallback: number): number {
+    const raw = process.env[name];
+    if (raw === undefined) return fallback;
+    const n = Number(raw);
+    return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+export function defaultProbeOptions(): Required<ProbeOptions> {
+    return {
+        timeoutMs: envNumber('KLARES4_MATTER_REGISTER_TIMEOUT_MS', DEFAULT_TIMEOUT_MS),
+        initialDelayMs: envNumber('KLARES4_MATTER_REGISTER_POLL_MS', DEFAULT_POLL_INITIAL_MS),
+        maxDelayMs: envNumber('KLARES4_MATTER_REGISTER_POLL_MAX_MS', DEFAULT_POLL_MAX_MS),
+    };
+}
+
+export async function probeUntilQueryable(
+    api: API,
+    log: Logger,
+    fmtErr: (err: unknown) => string,
+    reg: MatterRegistration,
+    options: ProbeOptions = {},
+): Promise<boolean> {
+    const cfg = { ...defaultProbeOptions(), ...options };
+    const deadline = Date.now() + cfg.timeoutMs;
+    let delay = cfg.initialDelayMs;
+
+    while (Date.now() < deadline) {
+        if (await isMatterAccessoryQueryable(api, log, fmtErr, reg)) return true;
+        await sleep(delay);
+        delay = Math.min(cfg.maxDelayMs, Math.round(delay * 1.5));
+    }
+    // One last probe at the deadline boundary.
+    return isMatterAccessoryQueryable(api, log, fmtErr, reg);
+}
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/platform/matter-registration-recovery.ts
+++ b/src/platform/matter-registration-recovery.ts
@@ -1,0 +1,117 @@
+import type { API, Logger, MatterAccessory } from 'homebridge';
+import type { KseniaDevice, KseniaThermostat } from '../types';
+import { PLUGIN_NAME, PLATFORM_NAME } from '../settings';
+import type { KseniaWebSocketClient } from '../websocket-client';
+import { mapThermostatAsTemperatureSensor } from './matter-device-mapper';
+import { buildStateUpdates, type PendingMatterStateUpdate } from './matter-state-updates';
+
+const MATTER_REGISTER_RECOVERY_LIMIT = 2;
+
+export interface MatterRegistration {
+    uuid: string;
+    displayName: string;
+    deviceType: string;
+    matterAccessory: MatterAccessory;
+    status: 'pending' | 'registered' | 'failed' | 'skipped';
+    registeredAt?: number;
+    failedAt?: number;
+    lastError?: string;
+    recoveryAttempts: number;
+    pendingStateUpdates: PendingMatterStateUpdate[];
+}
+
+interface RecoveryDeps {
+    api: API;
+    log: Logger;
+    thermostatFallbackUUIDs: Set<string>;
+    getWsClient: () => KseniaWebSocketClient | undefined;
+    scheduleComplete: (uuid: string) => void;
+    fmtErr: (err: unknown) => string;
+    settleMs: number;
+    thermostatFallbackEnabled: boolean;
+}
+
+export async function isMatterAccessoryQueryable(
+    api: API,
+    log: Logger,
+    fmtErr: (err: unknown) => string,
+    reg: MatterRegistration,
+): Promise<boolean> {
+    const probeCluster = reg.pendingStateUpdates[0]?.clusterName
+        ?? Object.keys(reg.matterAccessory.clusters ?? {})[0];
+    if (!probeCluster) return true;
+
+    try {
+        const current = await api.matter!.getAccessoryState(reg.uuid, probeCluster);
+        return current !== undefined;
+    } catch (err) {
+        log.debug(`[Matter] metadata probe failed for ${reg.displayName}: ${fmtErr(err)}`);
+        return false;
+    }
+}
+
+export async function handleMissingRegisteredAccessory(
+    reg: MatterRegistration,
+    deps: RecoveryDeps,
+): Promise<void> {
+    reg.recoveryAttempts += 1;
+
+    const device = reg.matterAccessory.context.device as KseniaDevice | undefined;
+    const shouldFallbackThermostat = reg.deviceType === 'thermostat'
+        && !!device
+        && !deps.thermostatFallbackUUIDs.has(reg.uuid)
+        && deps.thermostatFallbackEnabled;
+
+    if (shouldFallbackThermostat) {
+        deps.log.warn(
+            `[Matter] ${reg.displayName} was not queryable after registration; `
+            + 'falling back to TemperatureSensor before sending state updates.',
+        );
+        try {
+            await registerFallbackAccessory(device as KseniaThermostat, reg, deps);
+            return;
+        } catch (err) {
+            deps.log.warn(`[Matter] Fallback TemperatureSensor failed for ${reg.displayName}: ${deps.fmtErr(err)}`);
+        }
+    }
+
+    if (reg.recoveryAttempts <= MATTER_REGISTER_RECOVERY_LIMIT) {
+        deps.log.warn(
+            `[Matter] ${reg.displayName} was not queryable after registration; retrying registration `
+            + `(${reg.recoveryAttempts}/${MATTER_REGISTER_RECOVERY_LIMIT}).`,
+        );
+        try {
+            await deps.api.matter!.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [reg.matterAccessory]);
+            deps.scheduleComplete(reg.uuid);
+            return;
+        } catch (err) {
+            deps.log.warn(`[Matter] Registration retry failed for ${reg.displayName}: ${deps.fmtErr(err)}`);
+        }
+    }
+
+    reg.status = 'failed';
+    reg.failedAt = Date.now();
+    reg.lastError = 'Matter accessory not queryable after registration';
+    reg.pendingStateUpdates = [];
+    deps.log.warn(`[Matter] accessory failed: ${reg.displayName} — ${reg.lastError}`);
+}
+
+export async function registerFallbackAccessory(
+    device: KseniaThermostat,
+    reg: MatterRegistration,
+    deps: Pick<RecoveryDeps, 'api' | 'log' | 'getWsClient' | 'thermostatFallbackUUIDs' | 'scheduleComplete' | 'settleMs'>,
+): Promise<void> {
+    const fallback = mapThermostatAsTemperatureSensor(device, {
+        api: deps.api,
+        log: deps.log,
+        getWsClient: deps.getWsClient,
+    });
+    await deps.api.matter!.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [fallback]);
+    deps.thermostatFallbackUUIDs.add(device.id);
+    reg.matterAccessory = fallback;
+    reg.status = 'pending';
+    reg.recoveryAttempts = 0;
+    reg.pendingStateUpdates = buildStateUpdates(device, true);
+    deps.log.debug(`[Matter] settle started (${deps.settleMs}ms): ${device.name} [fallback]`);
+    deps.scheduleComplete(device.id);
+}

--- a/src/platform/matter-registration-recovery.ts
+++ b/src/platform/matter-registration-recovery.ts
@@ -28,8 +28,9 @@ interface RecoveryDeps {
     getWsClient: () => KseniaWebSocketClient | undefined;
     scheduleComplete: (uuid: string) => void;
     fmtErr: (err: unknown) => string;
-    settleMs: number;
     thermostatFallbackEnabled: boolean;
+    momentaryAutoOffMs?: number;
+    onFallbackPersist?: (uuid: string) => void;
 }
 
 export async function isMatterAccessoryQueryable(
@@ -100,19 +101,21 @@ export async function handleMissingRegisteredAccessory(
 export async function registerFallbackAccessory(
     device: KseniaThermostat,
     reg: MatterRegistration,
-    deps: Pick<RecoveryDeps, 'api' | 'log' | 'getWsClient' | 'thermostatFallbackUUIDs' | 'scheduleComplete' | 'settleMs'>,
+    deps: Pick<RecoveryDeps, 'api' | 'log' | 'getWsClient' | 'thermostatFallbackUUIDs' | 'scheduleComplete' | 'momentaryAutoOffMs' | 'onFallbackPersist'>,
 ): Promise<void> {
     const fallback = mapThermostatAsTemperatureSensor(device, {
         api: deps.api,
         log: deps.log,
         getWsClient: deps.getWsClient,
+        momentaryAutoOffMs: deps.momentaryAutoOffMs,
     });
     await deps.api.matter!.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [fallback]);
     deps.thermostatFallbackUUIDs.add(device.id);
+    deps.onFallbackPersist?.(device.id);
     reg.matterAccessory = fallback;
     reg.status = 'pending';
     reg.recoveryAttempts = 0;
     reg.pendingStateUpdates = buildStateUpdates(device, true);
-    deps.log.debug(`[Matter] settle started (${deps.settleMs}ms): ${device.name} [fallback]`);
+    deps.log.debug(`[Matter] fallback registered, probing: ${device.name}`);
     deps.scheduleComplete(device.id);
 }

--- a/src/platform/matter-registration-recovery.ts
+++ b/src/platform/matter-registration-recovery.ts
@@ -14,6 +14,7 @@ export interface MatterRegistration {
     matterAccessory: MatterAccessory;
     status: 'pending' | 'registered' | 'failed' | 'skipped';
     registeredAt?: number;
+    stateUpdatesReadyAt?: number;
     failedAt?: number;
     lastError?: string;
     recoveryAttempts: number;

--- a/src/platform/matter-state-update-queue.ts
+++ b/src/platform/matter-state-update-queue.ts
@@ -1,0 +1,75 @@
+import type { API, Logger } from 'homebridge';
+import type { MatterRegistration } from './matter-registration-recovery';
+import type { PendingMatterStateUpdate } from './matter-state-updates';
+
+const MATTER_STATE_UPDATE_RETRY_MS = 5000;
+const MATTER_STATE_UPDATE_RETRY_LIMIT = 6;
+
+export class MatterStateUpdateQueue {
+    constructor(
+        private readonly api: API,
+        private readonly log: Logger,
+        private readonly registrations: Map<string, MatterRegistration>,
+        private readonly fmtErr: (err: unknown) => string,
+    ) {}
+
+    public async pushOrQueue(
+        reg: MatterRegistration,
+        update: PendingMatterStateUpdate,
+        attempt = 0,
+    ): Promise<void> {
+        if (!await this.isClusterQueryable(reg, update)) {
+            this.queue(reg, update);
+            this.scheduleFlush(reg.uuid, attempt + 1);
+            return;
+        }
+
+        this.api.matter!.updateAccessoryState(reg.uuid, update.clusterName, update.attributes, update.partId);
+    }
+
+    public scheduleFlush(uuid: string, attempt: number): void {
+        const reg = this.registrations.get(uuid);
+        if (!reg || reg.pendingStateUpdates.length === 0) return;
+
+        if (attempt > MATTER_STATE_UPDATE_RETRY_LIMIT) {
+            this.log.warn(
+                `[Matter] pending state updates dropped for ${reg.displayName}: Matter endpoint was not ready `
+                + `after ${MATTER_STATE_UPDATE_RETRY_LIMIT} retries.`,
+            );
+            reg.pendingStateUpdates = [];
+            return;
+        }
+
+        const delay = attempt === 0 ? MATTER_STATE_UPDATE_RETRY_MS : MATTER_STATE_UPDATE_RETRY_MS * attempt;
+        setTimeout(() => { void this.flush(uuid, attempt); }, delay);
+    }
+
+    private async flush(uuid: string, attempt: number): Promise<void> {
+        const reg = this.registrations.get(uuid);
+        if (!reg || reg.status !== 'registered' || reg.pendingStateUpdates.length === 0) return;
+
+        const pending = reg.pendingStateUpdates.splice(0);
+        this.log.debug(`[Matter] pending updates flush attempt ${attempt + 1}: ${reg.displayName} (${pending.length})`);
+        for (const update of pending) {
+            await this.pushOrQueue(reg, update, attempt);
+        }
+    }
+
+    private async isClusterQueryable(reg: MatterRegistration, update: PendingMatterStateUpdate): Promise<boolean> {
+        try {
+            const current = await this.api.matter!.getAccessoryState(reg.uuid, update.clusterName, update.partId);
+            return current !== undefined;
+        } catch (err) {
+            this.log.debug(`[Matter] state probe failed for ${reg.displayName} (${update.clusterName}): ${this.fmtErr(err)}`);
+            return false;
+        }
+    }
+
+    private queue(reg: MatterRegistration, update: PendingMatterStateUpdate): void {
+        const idx = reg.pendingStateUpdates.findIndex(
+            (p) => p.clusterName === update.clusterName && p.partId === update.partId,
+        );
+        if (idx >= 0) reg.pendingStateUpdates[idx] = update;
+        else reg.pendingStateUpdates.push(update);
+    }
+}

--- a/src/platform/matter-state-update-queue.ts
+++ b/src/platform/matter-state-update-queue.ts
@@ -2,7 +2,11 @@ import type { API, Logger } from 'homebridge';
 import type { MatterRegistration } from './matter-registration-recovery';
 import type { PendingMatterStateUpdate } from './matter-state-updates';
 
-const DEFAULT_MATTER_STATE_UPDATE_BOOTSTRAP_MS = 30000;
+// With the probe-based settle in MatterAccessoryRegistry (Fix 2), the endpoint
+// is only marked `registered` once `getAccessoryState` actually returns. No
+// additional bootstrap delay is needed; the env var stays available as an
+// emergency override.
+const DEFAULT_MATTER_STATE_UPDATE_BOOTSTRAP_MS = 0;
 const MATTER_STATE_UPDATE_BOOTSTRAP_MS = Number(
     process.env.KLARES4_MATTER_STATE_BOOTSTRAP_MS ?? DEFAULT_MATTER_STATE_UPDATE_BOOTSTRAP_MS,
 );

--- a/src/platform/matter-state-update-queue.ts
+++ b/src/platform/matter-state-update-queue.ts
@@ -2,10 +2,14 @@ import type { API, Logger } from 'homebridge';
 import type { MatterRegistration } from './matter-registration-recovery';
 import type { PendingMatterStateUpdate } from './matter-state-updates';
 
-const MATTER_STATE_UPDATE_RETRY_MS = 5000;
-const MATTER_STATE_UPDATE_RETRY_LIMIT = 6;
+const DEFAULT_MATTER_STATE_UPDATE_BOOTSTRAP_MS = 30000;
+const MATTER_STATE_UPDATE_BOOTSTRAP_MS = Number(
+    process.env.KLARES4_MATTER_STATE_BOOTSTRAP_MS ?? DEFAULT_MATTER_STATE_UPDATE_BOOTSTRAP_MS,
+);
 
 export class MatterStateUpdateQueue {
+    private readonly flushTimers = new Map<string, NodeJS.Timeout>();
+
     constructor(
         private readonly api: API,
         private readonly log: Logger,
@@ -13,55 +17,60 @@ export class MatterStateUpdateQueue {
         private readonly fmtErr: (err: unknown) => string,
     ) {}
 
+    public markReadyAfterBootstrap(reg: MatterRegistration): void {
+        reg.stateUpdatesReadyAt = Date.now() + MATTER_STATE_UPDATE_BOOTSTRAP_MS;
+    }
+
     public async pushOrQueue(
         reg: MatterRegistration,
         update: PendingMatterStateUpdate,
-        attempt = 0,
     ): Promise<void> {
-        if (!await this.isClusterQueryable(reg, update)) {
+        if (!this.isReadyForStateUpdates(reg)) {
             this.queue(reg, update);
-            this.scheduleFlush(reg.uuid, attempt + 1);
+            this.scheduleFlush(reg.uuid);
             return;
         }
 
-        this.api.matter!.updateAccessoryState(reg.uuid, update.clusterName, update.attributes, update.partId);
+        await this.updateAccessoryState(reg, update);
     }
 
-    public scheduleFlush(uuid: string, attempt: number): void {
+    public scheduleFlush(uuid: string): void {
         const reg = this.registrations.get(uuid);
         if (!reg || reg.pendingStateUpdates.length === 0) return;
+        if (this.flushTimers.has(uuid)) return;
 
-        if (attempt > MATTER_STATE_UPDATE_RETRY_LIMIT) {
-            this.log.warn(
-                `[Matter] pending state updates dropped for ${reg.displayName}: Matter endpoint was not ready `
-                + `after ${MATTER_STATE_UPDATE_RETRY_LIMIT} retries.`,
-            );
-            reg.pendingStateUpdates = [];
+        const delay = Math.max(0, (reg.stateUpdatesReadyAt ?? Date.now()) - Date.now());
+        const timer = setTimeout(() => {
+            this.flushTimers.delete(uuid);
+            void this.flush(uuid);
+        }, delay);
+        this.flushTimers.set(uuid, timer);
+    }
+
+    private async flush(uuid: string): Promise<void> {
+        const reg = this.registrations.get(uuid);
+        if (!reg || reg.status !== 'registered' || reg.pendingStateUpdates.length === 0) return;
+        if (!this.isReadyForStateUpdates(reg)) {
+            this.scheduleFlush(uuid);
             return;
         }
 
-        const delay = attempt === 0 ? MATTER_STATE_UPDATE_RETRY_MS : MATTER_STATE_UPDATE_RETRY_MS * attempt;
-        setTimeout(() => { void this.flush(uuid, attempt); }, delay);
-    }
-
-    private async flush(uuid: string, attempt: number): Promise<void> {
-        const reg = this.registrations.get(uuid);
-        if (!reg || reg.status !== 'registered' || reg.pendingStateUpdates.length === 0) return;
-
         const pending = reg.pendingStateUpdates.splice(0);
-        this.log.debug(`[Matter] pending updates flush attempt ${attempt + 1}: ${reg.displayName} (${pending.length})`);
+        this.log.debug(`[Matter] pending updates flush: ${reg.displayName} (${pending.length})`);
         for (const update of pending) {
-            await this.pushOrQueue(reg, update, attempt);
+            await this.updateAccessoryState(reg, update);
         }
     }
 
-    private async isClusterQueryable(reg: MatterRegistration, update: PendingMatterStateUpdate): Promise<boolean> {
+    private isReadyForStateUpdates(reg: MatterRegistration): boolean {
+        return !reg.stateUpdatesReadyAt || Date.now() >= reg.stateUpdatesReadyAt;
+    }
+
+    private async updateAccessoryState(reg: MatterRegistration, update: PendingMatterStateUpdate): Promise<void> {
         try {
-            const current = await this.api.matter!.getAccessoryState(reg.uuid, update.clusterName, update.partId);
-            return current !== undefined;
+            await this.api.matter!.updateAccessoryState(reg.uuid, update.clusterName, update.attributes, update.partId);
         } catch (err) {
-            this.log.debug(`[Matter] state probe failed for ${reg.displayName} (${update.clusterName}): ${this.fmtErr(err)}`);
-            return false;
+            this.log.debug(`[Matter] state update failed for ${reg.displayName} (${update.clusterName}): ${this.fmtErr(err)}`);
         }
     }
 

--- a/src/platform/matter-state-updates.ts
+++ b/src/platform/matter-state-updates.ts
@@ -1,0 +1,123 @@
+/**
+ * Build Matter cluster state-update payloads from a Lares4 device.
+ *
+ * Pure functions, no side effects. Used by `MatterAccessoryRegistry` for both
+ * the immediate-push and queue-for-flush paths.
+ */
+
+import type { KseniaDevice, KseniaThermostat } from '../types';
+import {
+    toCentidegrees,
+    clampCentidegrees,
+    luxToMatterIlluminance,
+} from './matter-device-mapper';
+import { buildThermostatMatterState } from './matter-thermostat-mapper';
+
+export interface PendingMatterStateUpdate {
+    clusterName: string;
+    attributes: Record<string, unknown>;
+    partId?: string;
+}
+
+/**
+ * Build the cluster-level updates representing the device's current state.
+ *
+ * @param device  Lares4 device snapshot
+ * @param thermostatAsFallback  if true, push to `temperatureMeasurement` (used when
+ *                              the Thermostat was registered as a TemperatureSensor fallback)
+ */
+export function buildStateUpdates(
+    device: KseniaDevice,
+    thermostatAsFallback = false,
+): PendingMatterStateUpdate[] {
+    const out: PendingMatterStateUpdate[] = [];
+
+    switch (device.type) {
+        case 'light':
+            out.push({ clusterName: 'onOff', attributes: { onOff: device.status.on } });
+            if (device.status.dimmable && device.status.brightness !== undefined) {
+                out.push({
+                    clusterName: 'levelControl',
+                    attributes: {
+                        currentLevel: Math.max(1, Math.round((device.status.brightness / 100) * 254)),
+                    },
+                });
+            }
+            break;
+
+        case 'cover': {
+            const matterPos = Math.round((100 - (device.status.position ?? 0)) * 100);
+            out.push({
+                clusterName: 'windowCovering',
+                attributes: {
+                    currentPositionLiftPercent100ths: matterPos,
+                    targetPositionLiftPercent100ths: matterPos,
+                },
+            });
+            break;
+        }
+
+        case 'thermostat':
+            if (thermostatAsFallback) {
+                out.push({
+                    clusterName: 'temperatureMeasurement',
+                    attributes: { measuredValue: clampCentidegrees(toCentidegrees(device.currentTemperature ?? 21)) },
+                });
+            } else {
+                const { base } = buildThermostatMatterState(device as KseniaThermostat);
+                out.push({ clusterName: 'thermostat', attributes: base });
+            }
+            break;
+
+        case 'sensor': {
+            const val = device.status.value;
+            switch (device.status.sensorType) {
+                case 'temperature':
+                    out.push({
+                        clusterName: 'temperatureMeasurement',
+                        attributes: { measuredValue: clampCentidegrees(toCentidegrees(val)) },
+                    });
+                    break;
+                case 'humidity':
+                    out.push({
+                        clusterName: 'relativeHumidityMeasurement',
+                        attributes: { measuredValue: Math.round(Math.max(0, Math.min(100, val)) * 100) },
+                    });
+                    break;
+                case 'light':
+                    out.push({
+                        clusterName: 'illuminanceMeasurement',
+                        attributes: { measuredValue: luxToMatterIlluminance(val) },
+                    });
+                    break;
+                case 'motion':
+                    out.push({
+                        clusterName: 'occupancySensing',
+                        attributes: { occupancy: { occupied: val > 0 } },
+                    });
+                    break;
+                case 'contact':
+                    out.push({
+                        clusterName: 'booleanState',
+                        attributes: { stateValue: val === 0 },
+                    });
+                    break;
+            }
+            break;
+        }
+
+        case 'zone':
+            out.push({ clusterName: 'booleanState', attributes: { stateValue: !device.status.open } });
+            break;
+
+        case 'scenario':
+            out.push({ clusterName: 'onOff', attributes: { onOff: device.status.active } });
+            break;
+
+        case 'gate':
+            out.push({ clusterName: 'onOff', attributes: { onOff: device.status.on } });
+            break;
+    }
+
+    return out;
+}

--- a/src/platform/matter-state-updates.ts
+++ b/src/platform/matter-state-updates.ts
@@ -111,11 +111,14 @@ export function buildStateUpdates(
             break;
 
         case 'scenario':
-            out.push({ clusterName: 'onOff', attributes: { onOff: device.status.active } });
+            // Momentary trigger: state in Matter is always reported as off; the
+            // mapper's `on` handler auto-resets after a short delay.
+            out.push({ clusterName: 'onOff', attributes: { onOff: false } });
             break;
 
         case 'gate':
-            out.push({ clusterName: 'onOff', attributes: { onOff: device.status.on } });
+            // Momentary trigger: same pattern as scenarios.
+            out.push({ clusterName: 'onOff', attributes: { onOff: false } });
             break;
     }
 

--- a/src/platform/matter-thermostat-mapper.ts
+++ b/src/platform/matter-thermostat-mapper.ts
@@ -92,18 +92,11 @@ export function domainModeToMatterSystemMode(mode: DomainThermostatMode | undefi
 
 /**
  * matter.js 0.17 alpha applies the Presets-feature schema validation to the
- * Thermostat cluster even when Homebridge composes the device type with
- * `presets: false` (the `ThermostatBaseServer` enables the feature internally to
- * provide the default implementation, then exports the class with the default
- * feature set — but the schema-bound validators remain anchored to the base).
- *
- * Result: registering a Thermostat without `presetTypes` triggers
- *   [constraint] Validating ...thermostat.state.presetTypes:
- *   Constraint "1 to 7": Array length 0 is not within bounds defined by constraint
- *
- * Workaround: ship a single "Occupied" preset slot. The values mirror what
- * matter.js expects for `Thermostat.PresetType[]`. Remove this once
- * matter.js gates the validator on the active feature set.
+ * Thermostat cluster even when the device type is composed without the Presets
+ * feature, so `presetTypes` must be present with at least one entry. The
+ * `presetTypeFeatures` field is a bitmap and must be passed as an object —
+ * matter.js's BitmapManager rejects raw numbers ("Cannot manage number because
+ * it is not a bitmap object").
  *
  * Tracking: https://github.com/project-chip/matter.js/issues (search "presetTypes")
  */
@@ -114,7 +107,7 @@ export function getThermostatPresetWorkaroundAttributes(): Record<string, unknow
             {
                 presetScenario: PRESET_SCENARIO_OCCUPIED,
                 numberOfPresets: 1,
-                presetTypeFeatures: 0, // bitmap8: no automatic, no supportsNames
+                presetTypeFeatures: { automatic: false, supportsNames: false },
             },
         ],
     };

--- a/src/platform/matter-thermostat-mapper.ts
+++ b/src/platform/matter-thermostat-mapper.ts
@@ -1,0 +1,235 @@
+/**
+ * Matter Thermostat mapping helpers.
+ *
+ * Isolates all Thermostat-specific logic: temperature conversions, default ranges,
+ * deadband enforcement, system-mode mapping, and the presetTypes workaround
+ * required by matter.js 0.17 (see comment on `getThermostatPresetWorkaroundAttributes`).
+ *
+ * Pure functions only — no side effects, no I/O — to keep the unit tests trivial.
+ */
+
+import type { KseniaThermostat } from '../types';
+
+// ---------------------------------------------------------------------------
+// Constants (Matter spec §4.3 + sensible defaults for residential heating systems)
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_MIN_HEAT_C = 5;
+export const DEFAULT_MAX_HEAT_C = 30;
+export const DEFAULT_MIN_COOL_C = 16;
+export const DEFAULT_MAX_COOL_C = 35;
+export const DEFAULT_DEADBAND_C = 2;
+export const DEFAULT_HEATING_SETPOINT_C = 20;
+export const DEFAULT_COOLING_SETPOINT_C = 24;
+export const DEFAULT_LOCAL_TEMPERATURE_C = 20;
+
+// Matter temperature attribute hard limits (int16, centidegrees)
+export const TEMP_ABS_MIN_CENTI = -27000; // −270.00 °C
+export const TEMP_ABS_MAX_CENTI = 10000;  //  100.00 °C
+
+// ControlSequenceOfOperationEnum (Matter spec §4.3.7.30)
+export const CONTROL_SEQ_HEATING_ONLY = 2;
+export const CONTROL_SEQ_COOLING_AND_HEATING = 4;
+
+// SystemModeEnum (Matter spec §4.3.7.32)
+export const SYSTEM_MODE_OFF = 0;
+export const SYSTEM_MODE_AUTO = 1;
+export const SYSTEM_MODE_COOL = 3;
+export const SYSTEM_MODE_HEAT = 4;
+
+// PresetScenarioEnum (Matter spec §4.3.8.16)
+export const PRESET_SCENARIO_OCCUPIED = 1;
+
+// ---------------------------------------------------------------------------
+// Temperature helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert °C to Matter centidegrees (int16, factor 100).
+ * Coerces strings, rejects NaN/null/undefined returning the provided fallback.
+ */
+export function toMatterTemperatureCelsius(value: unknown, fallbackC = 0): number {
+    const n = coerceToFiniteNumber(value);
+    if (n === undefined) return Math.round(fallbackC * 100);
+    return Math.round(n * 100);
+}
+
+/** Convert Matter centidegrees back to °C. */
+export function fromMatterTemperatureCelsius(value: number): number {
+    return value / 100;
+}
+
+/** Clamp a Matter-encoded temperature to the supplied (centidegree) bounds. */
+export function clampMatterTemperature(valueCenti: number, minCenti: number, maxCenti: number): number {
+    if (Number.isNaN(valueCenti)) return minCenti;
+    return Math.max(minCenti, Math.min(maxCenti, valueCenti));
+}
+
+function coerceToFiniteNumber(value: unknown): number | undefined {
+    if (value === null || value === undefined) return undefined;
+    const n = typeof value === 'string' ? Number(value) : (value as number);
+    return Number.isFinite(n) ? n : undefined;
+}
+
+// ---------------------------------------------------------------------------
+// SystemMode / ControlSequenceOfOperation
+// ---------------------------------------------------------------------------
+
+export type DomainThermostatMode = 'off' | 'heat' | 'cool' | 'auto';
+
+export function domainModeToMatterSystemMode(mode: DomainThermostatMode | undefined): number {
+    switch (mode) {
+        case 'heat': return SYSTEM_MODE_HEAT;
+        case 'cool': return SYSTEM_MODE_COOL;
+        case 'auto': return SYSTEM_MODE_AUTO;
+        default:     return SYSTEM_MODE_OFF;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Preset workaround (matter.js 0.17 quirk)
+// ---------------------------------------------------------------------------
+
+/**
+ * matter.js 0.17 alpha applies the Presets-feature schema validation to the
+ * Thermostat cluster even when Homebridge composes the device type with
+ * `presets: false` (the `ThermostatBaseServer` enables the feature internally to
+ * provide the default implementation, then exports the class with the default
+ * feature set — but the schema-bound validators remain anchored to the base).
+ *
+ * Result: registering a Thermostat without `presetTypes` triggers
+ *   [constraint] Validating ...thermostat.state.presetTypes:
+ *   Constraint "1 to 7": Array length 0 is not within bounds defined by constraint
+ *
+ * Workaround: ship a single "Occupied" preset slot. The values mirror what
+ * matter.js expects for `Thermostat.PresetType[]`. Remove this once
+ * matter.js gates the validator on the active feature set.
+ *
+ * Tracking: https://github.com/project-chip/matter.js/issues (search "presetTypes")
+ */
+export function getThermostatPresetWorkaroundAttributes(): Record<string, unknown> {
+    return {
+        numberOfPresets: 1,
+        presetTypes: [
+            {
+                presetScenario: PRESET_SCENARIO_OCCUPIED,
+                numberOfPresets: 1,
+                presetTypeFeatures: 0, // bitmap8: no automatic, no supportsNames
+            },
+        ],
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Capability detection (heuristic — Lares4 zone names follow Italian conventions)
+// ---------------------------------------------------------------------------
+
+/**
+ * Decide whether a Lares4 thermostat should expose Matter cooling.
+ * The Lares4 system itself does not expose this metadata in the WS payload,
+ * but the standard installer naming convention is "Riscaldamento_*" for heating-only
+ * and "Raffrescamento_*" / "Climatizzazione_*" for HVAC with cooling.
+ *
+ * Heuristic only — when in doubt we default to HeatingOnly (more restrictive,
+ * less likely to surprise users with a fake cooling slider).
+ */
+export function thermostatSupportsCooling(device: KseniaThermostat): boolean {
+    const name = device.name?.toLowerCase() ?? '';
+    return name.includes('raffrescamento')
+        || name.includes('raffreddamento')
+        || name.includes('climatizzazione')
+        || name.includes('cooling')
+        || name.includes('cool');
+}
+
+// ---------------------------------------------------------------------------
+// Full Thermostat attribute payload (centralised — used by both register and update flows)
+// ---------------------------------------------------------------------------
+
+export interface ThermostatMatterState {
+    /** Mandatory Thermostat attributes used at register time and on every state update. */
+    base: Record<string, unknown>;
+    /** Static schema-mandated attributes (limits, deadband, preset workaround) — register-time only. */
+    schemaInvariants: Record<string, unknown>;
+}
+
+/**
+ * Build the full Thermostat cluster state for a Lares4 thermostat.
+ *
+ * The Homebridge 2 Thermostat device type enables HEAT + COOL + AUTO + OCC features
+ * (see `node_modules/homebridge/dist/matter/types.js`). All mandatory attributes for
+ * these features must be present at register time. Updates pushed via
+ * `api.matter.updateAccessoryState(...)` only need the dynamic subset (`base`).
+ *
+ * @param device Lares4 thermostat device
+ */
+export function buildThermostatMatterState(device: KseniaThermostat): ThermostatMatterState {
+    // Convert + clamp to absolute Matter bounds, with safe fallbacks for null/undefined/NaN.
+    const localTempC = coerceToFiniteNumber(device.currentTemperature) ?? DEFAULT_LOCAL_TEMPERATURE_C;
+    const heatingTargetC = coerceToFiniteNumber(device.targetTemperature) ?? DEFAULT_HEATING_SETPOINT_C;
+
+    const heatMinCenti = Math.round(DEFAULT_MIN_HEAT_C * 100);
+    const heatMaxCenti = Math.round(DEFAULT_MAX_HEAT_C * 100);
+    const coolMinCenti = Math.round(DEFAULT_MIN_COOL_C * 100);
+    const coolMaxCenti = Math.round(DEFAULT_MAX_COOL_C * 100);
+    const deadbandCenti = Math.round(DEFAULT_DEADBAND_C * 100);
+
+    const localTempCenti = clampMatterTemperature(toMatterTemperatureCelsius(localTempC), TEMP_ABS_MIN_CENTI, TEMP_ABS_MAX_CENTI);
+    const heatingSetpointCenti = clampMatterTemperature(toMatterTemperatureCelsius(heatingTargetC), heatMinCenti, heatMaxCenti);
+
+    // AUTO-feature invariant: occupiedCoolingSetpoint - occupiedHeatingSetpoint >= minSetpointDeadBand.
+    // If the natural cooling default would violate this, push it up to heating + deadband.
+    const coolingTargetCenti = clampMatterTemperature(
+        Math.max(Math.round(DEFAULT_COOLING_SETPOINT_C * 100), heatingSetpointCenti + deadbandCenti),
+        coolMinCenti,
+        coolMaxCenti,
+    );
+
+    // If after clamping the cool side, the gap is still smaller than the deadband
+    // (only possible at the very top of the cooling range), drag heating down instead.
+    const enforcedHeatingSetpointCenti = (coolingTargetCenti - heatingSetpointCenti < deadbandCenti)
+        ? Math.max(heatMinCenti, coolingTargetCenti - deadbandCenti)
+        : heatingSetpointCenti;
+
+    const supportsCooling = thermostatSupportsCooling(device);
+    const controlSequence = supportsCooling
+        ? CONTROL_SEQ_COOLING_AND_HEATING
+        : CONTROL_SEQ_HEATING_ONLY;
+
+    // The Homebridge bundled device type still ships the HEAT+COOL+AUTO+OCC features.
+    // Even on a heating-only Lares4 zone, omitting cooling attributes will violate the
+    // cluster schema. We ship them anyway with sane values but set the control sequence
+    // so HomeKit/Matter clients understand which modes are meaningful.
+
+    const systemMode = domainModeToMatterSystemMode(device.mode);
+    // When ControlSequence is HeatingOnly, valid SystemMode values are {Off, Heat}.
+    // Coerce cool/auto → heat so the cluster invariant holds.
+    const coerencedSystemMode = (!supportsCooling && (systemMode === SYSTEM_MODE_COOL || systemMode === SYSTEM_MODE_AUTO))
+        ? SYSTEM_MODE_HEAT
+        : systemMode;
+
+    const base: Record<string, unknown> = {
+        localTemperature: localTempCenti,
+        occupiedHeatingSetpoint: enforcedHeatingSetpointCenti,
+        occupiedCoolingSetpoint: coolingTargetCenti,
+        unoccupiedHeatingSetpoint: enforcedHeatingSetpointCenti,
+        unoccupiedCoolingSetpoint: coolingTargetCenti,
+        systemMode: coerencedSystemMode,
+    };
+
+    const schemaInvariants: Record<string, unknown> = {
+        absMinHeatSetpointLimit: heatMinCenti,
+        absMaxHeatSetpointLimit: heatMaxCenti,
+        minHeatSetpointLimit: heatMinCenti,
+        maxHeatSetpointLimit: heatMaxCenti,
+        absMinCoolSetpointLimit: coolMinCenti,
+        absMaxCoolSetpointLimit: coolMaxCenti,
+        minCoolSetpointLimit: coolMinCenti,
+        maxCoolSetpointLimit: coolMaxCenti,
+        minSetpointDeadBand: Math.round(DEFAULT_DEADBAND_C * 10), // int8s in tenths of °C
+        controlSequenceOfOperation: controlSequence,
+        ...getThermostatPresetWorkaroundAttributes(),
+    };
+
+    return { base, schemaInvariants };
+}

--- a/src/plugin-version.ts
+++ b/src/plugin-version.ts
@@ -1,0 +1,8 @@
+import { version as RAW_VERSION } from '../package.json';
+
+// FirmwareRevision conforme HAP/Matter: solo MAJOR.MINOR.PATCH, senza suffissi.
+// Matter rifiuta suffissi tipo `-beta0`, `-rc1`, `+build`.
+// Es: "2.1.0-beta0" → "2.1.0", "2.1.0" → "2.1.0".
+export const PLUGIN_VERSION: string = RAW_VERSION.split(/[-+]/)[0];
+
+export const PLUGIN_VERSION_RAW: string = RAW_VERSION;

--- a/test/matter-accessory-registry.test.js
+++ b/test/matter-accessory-registry.test.js
@@ -1,6 +1,8 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
+process.env.KLARES4_MATTER_STATE_BOOTSTRAP_MS = '1000';
+
 const { MatterAccessoryRegistry } = require('../dist/platform/matter-accessory-registry.js');
 
 // Mirrors api.matter.deviceTypes — we don't need the real Matter device types, just placeholder
@@ -105,8 +107,8 @@ function delay(ms) {
     return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-const SETTLE_AND_UPDATE_FLUSH_MS = 7200;
-const FALLBACK_SETTLE_AND_UPDATE_FLUSH_MS = 9400;
+const SETTLE_AND_UPDATE_FLUSH_MS = 3400;
+const FALLBACK_SETTLE_AND_UPDATE_FLUSH_MS = 5600;
 
 // ---------------------------------------------------------------------------
 
@@ -179,7 +181,7 @@ test('post-settle: updates are pushed immediately', async () => {
     const { api, updates } = makeApi();
     const registry = new MatterAccessoryRegistry(api, silentLog(), () => undefined);
     await registry.addOrUpdateAccessory(lightDevice('light_5'));
-    await delay(2100); // settle
+    await delay(SETTLE_AND_UPDATE_FLUSH_MS); // settle + state update bootstrap
     updates.length = 0;
     await registry.updateAccessoryState({ ...lightDevice('light_5'), status: { on: false, dimmable: false } });
     assert.equal(updates.length, 1);
@@ -272,7 +274,7 @@ test('thermostat fallback: state updates go to temperatureMeasurement, not therm
     });
     const registry = new MatterAccessoryRegistry(api, silentLog(), () => undefined);
     await registry.addOrUpdateAccessory(thermostatDevice('thermostat_70'));
-    await delay(2100);
+    await delay(FALLBACK_SETTLE_AND_UPDATE_FLUSH_MS);
     updates.length = 0;
     await registry.updateAccessoryState(thermostatDevice('thermostat_70', { currentTemperature: 19.5 }));
     assert.equal(updates.length, 1);

--- a/test/matter-accessory-registry.test.js
+++ b/test/matter-accessory-registry.test.js
@@ -25,6 +25,7 @@ function silentLog() {
 
 function makeApi({ registerImpl, updateImpl, unregisterImpl } = {}) {
     const registered = [];
+    const queryable = new Set();
     const updates = [];
     const metadataUpdates = [];
     const unregistered = [];
@@ -36,6 +37,9 @@ function makeApi({ registerImpl, updateImpl, unregisterImpl } = {}) {
                 if (registerImpl) {
                     const res = registerImpl(a);
                     if (res === 'throw') throw new Error('synthetic registration failure');
+                    if (res !== 'missing-state') queryable.add(a.UUID);
+                } else {
+                    queryable.add(a.UUID);
                 }
                 registered.push({ UUID: a.UUID, displayName: a.displayName, deviceType: a.deviceType });
             }
@@ -57,9 +61,15 @@ function makeApi({ registerImpl, updateImpl, unregisterImpl } = {}) {
             if (updateImpl) updateImpl(uuid, clusterName, attributes, partId);
             updates.push({ uuid, clusterName, attributes, partId });
         },
+        getAccessoryState: async (uuid) => {
+            return queryable.has(uuid) ? {} : undefined;
+        },
         unregisterPlatformAccessories: async (_p, _pl, accessories) => {
             if (unregisterImpl) unregisterImpl(accessories);
-            for (const a of accessories) unregistered.push(a.UUID);
+            for (const a of accessories) {
+                queryable.delete(a.UUID);
+                unregistered.push(a.UUID);
+            }
         },
     };
 
@@ -200,6 +210,30 @@ test('thermostat: falls back to TemperatureSensor when matter rejects the Thermo
     assert.equal(registered[0].deviceType._t, 'TemperatureSensor');
     await delay(2100);
     assert.equal(registry.getStatus('thermostat_60'), 'registered');
+});
+
+test('thermostat: async missing registration falls back before state updates', async () => {
+    let missingOnce = false;
+    const { api, registered, updates } = makeApi({
+        registerImpl: (acc) => {
+            if (!missingOnce && acc.deviceType._t === 'Thermostat') {
+                missingOnce = true;
+                return 'missing-state';
+            }
+            return undefined;
+        },
+    });
+    const registry = new MatterAccessoryRegistry(api, silentLog(), () => undefined);
+    await registry.addOrUpdateAccessory(thermostatDevice('thermostat_async_missing'));
+    await registry.updateAccessoryState(thermostatDevice('thermostat_async_missing', { currentTemperature: 19.5 }));
+    await delay(4300);
+
+    assert.equal(registry.getStatus('thermostat_async_missing'), 'registered');
+    assert.equal(registered[0].deviceType._t, 'Thermostat');
+    assert.equal(registered[1].deviceType._t, 'TemperatureSensor');
+    assert.equal(updates.length, 1);
+    assert.equal(updates[0].clusterName, 'temperatureMeasurement');
+    assert.equal(updates[0].attributes.measuredValue, 1950);
 });
 
 test('rediscovery refreshes cached Matter identity metadata when display name changes', async () => {

--- a/test/matter-accessory-registry.test.js
+++ b/test/matter-accessory-registry.test.js
@@ -26,6 +26,7 @@ function silentLog() {
 function makeApi({ registerImpl, updateImpl, unregisterImpl } = {}) {
     const registered = [];
     const updates = [];
+    const metadataUpdates = [];
     const unregistered = [];
 
     const matter = {
@@ -39,6 +40,19 @@ function makeApi({ registerImpl, updateImpl, unregisterImpl } = {}) {
                 registered.push({ UUID: a.UUID, displayName: a.displayName, deviceType: a.deviceType });
             }
         },
+        updatePlatformAccessories: async (accessories) => {
+            for (const a of accessories) {
+                metadataUpdates.push({
+                    UUID: a.UUID,
+                    displayName: a.displayName,
+                    manufacturer: a.manufacturer,
+                    model: a.model,
+                    serialNumber: a.serialNumber,
+                    firmwareRevision: a.firmwareRevision,
+                    deviceType: a.deviceType,
+                });
+            }
+        },
         updateAccessoryState: async (uuid, clusterName, attributes, partId) => {
             if (updateImpl) updateImpl(uuid, clusterName, attributes, partId);
             updates.push({ uuid, clusterName, attributes, partId });
@@ -50,7 +64,7 @@ function makeApi({ registerImpl, updateImpl, unregisterImpl } = {}) {
     };
 
     const api = { matter };
-    return { api, registered, updates, unregistered };
+    return { api, registered, updates, metadataUpdates, unregistered };
 }
 
 function lightDevice(id = 'light_1', extras = {}) {
@@ -95,13 +109,18 @@ test('does not crash when api.matter is undefined', async () => {
 });
 
 test('addOrUpdateAccessory: register → pending → settled → registered', async () => {
-    const { api, registered } = makeApi();
+    const { api, registered, metadataUpdates } = makeApi();
     const registry = new MatterAccessoryRegistry(api, silentLog(), () => undefined);
     await registry.addOrUpdateAccessory(lightDevice());
     assert.equal(registered.length, 1);
     assert.equal(registry.getStatus('light_1'), 'pending');
     await delay(2100); // > MATTER_REGISTER_SETTLE_MS
     assert.equal(registry.getStatus('light_1'), 'registered');
+    assert.equal(metadataUpdates.length, 1);
+    assert.equal(metadataUpdates[0].manufacturer, 'Ksenia');
+    assert.equal(metadataUpdates[0].model, 'Lares4 light');
+    assert.equal(metadataUpdates[0].serialNumber, 'light_1');
+    assert.match(metadataUpdates[0].firmwareRevision, /^\d+\.\d+\.\d+$/);
 });
 
 test('status updates received during the settle window are queued, not pushed', async () => {
@@ -181,6 +200,27 @@ test('thermostat: falls back to TemperatureSensor when matter rejects the Thermo
     assert.equal(registered[0].deviceType._t, 'TemperatureSensor');
     await delay(2100);
     assert.equal(registry.getStatus('thermostat_60'), 'registered');
+});
+
+test('rediscovery refreshes cached Matter identity metadata when display name changes', async () => {
+    const { api, metadataUpdates } = makeApi();
+    const registry = new MatterAccessoryRegistry(api, silentLog(), () => undefined);
+    await registry.addOrUpdateAccessory(lightDevice('light_meta'));
+    await delay(2100);
+    metadataUpdates.length = 0;
+
+    await registry.addOrUpdateAccessory(lightDevice('light_meta', { on: false }));
+    assert.equal(metadataUpdates.length, 0, 'unchanged metadata should not rewrite the cache');
+
+    await registry.addOrUpdateAccessory({
+        ...lightDevice('light_meta', { on: false }),
+        name: 'Luce Sala',
+    });
+    assert.equal(metadataUpdates.length, 1);
+    assert.equal(metadataUpdates[0].displayName, 'Luce Sala');
+    assert.equal(metadataUpdates[0].manufacturer, 'Ksenia');
+    assert.equal(metadataUpdates[0].model, 'Lares4 light');
+    assert.equal(metadataUpdates[0].serialNumber, 'light_meta');
 });
 
 test('thermostat fallback: state updates go to temperatureMeasurement, not thermostat cluster', async () => {

--- a/test/matter-accessory-registry.test.js
+++ b/test/matter-accessory-registry.test.js
@@ -1,9 +1,20 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const os = require('node:os');
+const fs = require('node:fs');
+const path = require('node:path');
 
 process.env.KLARES4_MATTER_STATE_BOOTSTRAP_MS = '1000';
+// Speed up probe-based settle in tests
+process.env.KLARES4_MATTER_REGISTER_TIMEOUT_MS = '500';
+process.env.KLARES4_MATTER_REGISTER_POLL_MS = '10';
+process.env.KLARES4_MATTER_REGISTER_POLL_MAX_MS = '20';
 
 const { MatterAccessoryRegistry } = require('../dist/platform/matter-accessory-registry.js');
+
+function tmpStorage() {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'klares4-test-'));
+}
 
 // Mirrors api.matter.deviceTypes — we don't need the real Matter device types, just placeholder
 // objects (the registry forwards them blindly to the mock register).
@@ -115,14 +126,16 @@ function delay(ms) {
     return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-const SETTLE_AND_UPDATE_FLUSH_MS = 3400;
-const FALLBACK_SETTLE_AND_UPDATE_FLUSH_MS = 5600;
+// Probe-based settle is fast in tests (queryable on first probe, ~10ms).
+// Bootstrap default is 0; the state-update env override (1000) still applies.
+const SETTLE_AND_UPDATE_FLUSH_MS = 1200;
+const FALLBACK_SETTLE_AND_UPDATE_FLUSH_MS = 2400;
 
 // ---------------------------------------------------------------------------
 
 test('does not crash when api.matter is undefined', async () => {
     const api = { matter: undefined };
-    const registry = new MatterAccessoryRegistry(api, silentLog(), () => undefined);
+    const registry = new MatterAccessoryRegistry({ api, log: silentLog(), getWsClient: () => undefined, storagePath: tmpStorage() });
     assert.equal(registry.isEnabled, false);
     await registry.addOrUpdateAccessory(lightDevice());
     await registry.updateAccessoryState(lightDevice());
@@ -133,11 +146,11 @@ test('does not crash when api.matter is undefined', async () => {
 
 test('addOrUpdateAccessory: register → pending → settled → registered', async () => {
     const { api, registered, metadataUpdates } = makeApi();
-    const registry = new MatterAccessoryRegistry(api, silentLog(), () => undefined);
+    const registry = new MatterAccessoryRegistry({ api, log: silentLog(), getWsClient: () => undefined, storagePath: tmpStorage() });
     await registry.addOrUpdateAccessory(lightDevice());
     assert.equal(registered.length, 1);
     assert.equal(registry.getStatus('light_1'), 'pending');
-    await delay(2100); // > MATTER_REGISTER_SETTLE_MS
+    await delay(200); // > MATTER_REGISTER_SETTLE_MS
     assert.equal(registry.getStatus('light_1'), 'registered');
     assert.equal(metadataUpdates.length, 0, 'must not call updatePlatformAccessories because it drops endpoints in HB2');
     assert.equal(registered[0].manufacturer, 'Ksenia');
@@ -148,7 +161,7 @@ test('addOrUpdateAccessory: register → pending → settled → registered', as
 
 test('status updates received during the settle window are queued, not pushed', async () => {
     const { api, updates } = makeApi();
-    const registry = new MatterAccessoryRegistry(api, silentLog(), () => undefined);
+    const registry = new MatterAccessoryRegistry({ api, log: silentLog(), getWsClient: () => undefined, storagePath: tmpStorage() });
     await registry.addOrUpdateAccessory(lightDevice('light_2'));
     assert.equal(registry.getStatus('light_2'), 'pending');
     assert.equal(updates.length, 0);
@@ -159,7 +172,7 @@ test('status updates received during the settle window are queued, not pushed', 
 
 test('queued updates are flushed after the settle window', async () => {
     const { api, updates } = makeApi();
-    const registry = new MatterAccessoryRegistry(api, silentLog(), () => undefined);
+    const registry = new MatterAccessoryRegistry({ api, log: silentLog(), getWsClient: () => undefined, storagePath: tmpStorage() });
     await registry.addOrUpdateAccessory(lightDevice('light_3'));
     await registry.updateAccessoryState({ ...lightDevice('light_3'), status: { on: false, dimmable: false } });
     assert.equal(updates.length, 0);
@@ -172,7 +185,7 @@ test('queued updates are flushed after the settle window', async () => {
 
 test('queue dedupes by (clusterName, partId): only latest payload is kept', async () => {
     const { api, updates } = makeApi();
-    const registry = new MatterAccessoryRegistry(api, silentLog(), () => undefined);
+    const registry = new MatterAccessoryRegistry({ api, log: silentLog(), getWsClient: () => undefined, storagePath: tmpStorage() });
     await registry.addOrUpdateAccessory(lightDevice('light_4'));
     // Three updates for the same cluster — only the last one should remain queued
     await registry.updateAccessoryState({ ...lightDevice('light_4'), status: { on: false, dimmable: false } });
@@ -187,20 +200,21 @@ test('queue dedupes by (clusterName, partId): only latest payload is kept', asyn
 
 test('post-settle: updates are pushed immediately', async () => {
     const { api, updates } = makeApi();
-    const registry = new MatterAccessoryRegistry(api, silentLog(), () => undefined);
+    const registry = new MatterAccessoryRegistry({ api, log: silentLog(), getWsClient: () => undefined, storagePath: tmpStorage() });
     await registry.addOrUpdateAccessory(lightDevice('light_5'));
     await delay(SETTLE_AND_UPDATE_FLUSH_MS); // settle + state update bootstrap
     updates.length = 0;
     await registry.updateAccessoryState({ ...lightDevice('light_5'), status: { on: false, dimmable: false } });
+    await delay(20); // post-bootstrap flush still goes through the queue's setTimeout(0)
     assert.equal(updates.length, 1);
     assert.deepEqual(updates[0].attributes, { onOff: false });
 });
 
 test('thermostat: registers as Thermostat when matter accepts it', async () => {
     const { api, registered } = makeApi();
-    const registry = new MatterAccessoryRegistry(api, silentLog(), () => undefined);
+    const registry = new MatterAccessoryRegistry({ api, log: silentLog(), getWsClient: () => undefined, storagePath: tmpStorage() });
     await registry.addOrUpdateAccessory(thermostatDevice('thermostat_50'));
-    await delay(2100);
+    await delay(200);
     assert.equal(registry.getStatus('thermostat_50'), 'registered');
     assert.equal(registered[0].deviceType._t, 'Thermostat');
 });
@@ -216,12 +230,12 @@ test('thermostat: falls back to TemperatureSensor when matter rejects the Thermo
             return undefined;
         },
     });
-    const registry = new MatterAccessoryRegistry(api, silentLog(), () => undefined);
+    const registry = new MatterAccessoryRegistry({ api, log: silentLog(), getWsClient: () => undefined, storagePath: tmpStorage() });
     await registry.addOrUpdateAccessory(thermostatDevice('thermostat_60'));
     // After failure, fallback should have been registered
     assert.equal(registered.length, 1, 'first attempt failed, fallback was retried with TemperatureSensor');
     assert.equal(registered[0].deviceType._t, 'TemperatureSensor');
-    await delay(2100);
+    await delay(200);
     assert.equal(registry.getStatus('thermostat_60'), 'registered');
 });
 
@@ -236,7 +250,7 @@ test('thermostat: async missing registration falls back before state updates', a
             return undefined;
         },
     });
-    const registry = new MatterAccessoryRegistry(api, silentLog(), () => undefined);
+    const registry = new MatterAccessoryRegistry({ api, log: silentLog(), getWsClient: () => undefined, storagePath: tmpStorage() });
     await registry.addOrUpdateAccessory(thermostatDevice('thermostat_async_missing'));
     await registry.updateAccessoryState(thermostatDevice('thermostat_async_missing', { currentTemperature: 19.5 }));
     await delay(FALLBACK_SETTLE_AND_UPDATE_FLUSH_MS);
@@ -251,9 +265,9 @@ test('thermostat: async missing registration falls back before state updates', a
 
 test('rediscovery updates in-memory Matter identity without updatePlatformAccessories', async () => {
     const { api, metadataUpdates } = makeApi();
-    const registry = new MatterAccessoryRegistry(api, silentLog(), () => undefined);
+    const registry = new MatterAccessoryRegistry({ api, log: silentLog(), getWsClient: () => undefined, storagePath: tmpStorage() });
     await registry.addOrUpdateAccessory(lightDevice('light_meta'));
-    await delay(2100);
+    await delay(200);
     metadataUpdates.length = 0;
 
     await registry.addOrUpdateAccessory(lightDevice('light_meta', { on: false }));
@@ -276,11 +290,12 @@ test('thermostat fallback: state updates go to temperatureMeasurement, not therm
             }
         },
     });
-    const registry = new MatterAccessoryRegistry(api, silentLog(), () => undefined);
+    const registry = new MatterAccessoryRegistry({ api, log: silentLog(), getWsClient: () => undefined, storagePath: tmpStorage() });
     await registry.addOrUpdateAccessory(thermostatDevice('thermostat_70'));
     await delay(FALLBACK_SETTLE_AND_UPDATE_FLUSH_MS);
     updates.length = 0;
     await registry.updateAccessoryState(thermostatDevice('thermostat_70', { currentTemperature: 19.5 }));
+    await delay(20);
     assert.equal(updates.length, 1);
     assert.equal(updates[0].clusterName, 'temperatureMeasurement');
     assert.equal(updates[0].attributes.measuredValue, 1950);
@@ -290,7 +305,7 @@ test('failed device: no further attempts, no log spam', async () => {
     const { api, registered } = makeApi({
         registerImpl: () => 'throw',
     });
-    const registry = new MatterAccessoryRegistry(api, silentLog(), () => undefined);
+    const registry = new MatterAccessoryRegistry({ api, log: silentLog(), getWsClient: () => undefined, storagePath: tmpStorage() });
     // Use a non-thermostat device (no fallback) to test the "failed" terminal state
     await registry.addOrUpdateAccessory(lightDevice('light_99'));
     assert.equal(registry.getStatus('light_99'), 'failed');
@@ -303,11 +318,11 @@ test('failed device: no further attempts, no log spam', async () => {
 
 test('prune: unregisters devices no longer present in discovery cycle', async () => {
     const { api, unregistered } = makeApi();
-    const registry = new MatterAccessoryRegistry(api, silentLog(), () => undefined);
+    const registry = new MatterAccessoryRegistry({ api, log: silentLog(), getWsClient: () => undefined, storagePath: tmpStorage() });
     registry.startDiscoveryCycle();
     await registry.addOrUpdateAccessory(lightDevice('light_a'));
     await registry.addOrUpdateAccessory(lightDevice('light_b'));
-    await delay(2100); // settle both
+    await delay(200); // settle both
 
     // New cycle — only light_a is rediscovered
     registry.startDiscoveryCycle();

--- a/test/matter-accessory-registry.test.js
+++ b/test/matter-accessory-registry.test.js
@@ -1,0 +1,236 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { MatterAccessoryRegistry } = require('../dist/platform/matter-accessory-registry.js');
+
+// Mirrors api.matter.deviceTypes — we don't need the real Matter device types, just placeholder
+// objects (the registry forwards them blindly to the mock register).
+const fakeDeviceTypes = {
+    OnOffLight: { _t: 'OnOffLight' },
+    DimmableLight: { _t: 'DimmableLight' },
+    WindowCovering: { _t: 'WindowCovering' },
+    Thermostat: { _t: 'Thermostat' },
+    TemperatureSensor: { _t: 'TemperatureSensor' },
+    HumiditySensor: { _t: 'HumiditySensor' },
+    LightSensor: { _t: 'LightSensor' },
+    MotionSensor: { _t: 'MotionSensor' },
+    ContactSensor: { _t: 'ContactSensor' },
+    OnOffSwitch: { _t: 'OnOffSwitch' },
+    OnOffOutlet: { _t: 'OnOffOutlet' },
+};
+
+function silentLog() {
+    return { info: () => {}, warn: () => {}, debug: () => {}, error: () => {} };
+}
+
+function makeApi({ registerImpl, updateImpl, unregisterImpl } = {}) {
+    const registered = [];
+    const updates = [];
+    const unregistered = [];
+
+    const matter = {
+        deviceTypes: fakeDeviceTypes,
+        registerPlatformAccessories: async (_p, _pl, accessories) => {
+            for (const a of accessories) {
+                if (registerImpl) {
+                    const res = registerImpl(a);
+                    if (res === 'throw') throw new Error('synthetic registration failure');
+                }
+                registered.push({ UUID: a.UUID, displayName: a.displayName, deviceType: a.deviceType });
+            }
+        },
+        updateAccessoryState: async (uuid, clusterName, attributes, partId) => {
+            if (updateImpl) updateImpl(uuid, clusterName, attributes, partId);
+            updates.push({ uuid, clusterName, attributes, partId });
+        },
+        unregisterPlatformAccessories: async (_p, _pl, accessories) => {
+            if (unregisterImpl) unregisterImpl(accessories);
+            for (const a of accessories) unregistered.push(a.UUID);
+        },
+    };
+
+    const api = { matter };
+    return { api, registered, updates, unregistered };
+}
+
+function lightDevice(id = 'light_1', extras = {}) {
+    return {
+        id,
+        type: 'light',
+        name: `Light ${id}`,
+        description: '',
+        status: { on: true, dimmable: false, ...extras },
+    };
+}
+
+function thermostatDevice(id = 'thermostat_18', extras = {}) {
+    return {
+        id,
+        type: 'thermostat',
+        name: 'Riscaldamento Sala',
+        description: '',
+        currentTemperature: 21,
+        targetTemperature: 20,
+        mode: 'heat',
+        status: {},
+        ...extras,
+    };
+}
+
+function delay(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ---------------------------------------------------------------------------
+
+test('does not crash when api.matter is undefined', async () => {
+    const api = { matter: undefined };
+    const registry = new MatterAccessoryRegistry(api, silentLog(), () => undefined);
+    assert.equal(registry.isEnabled, false);
+    await registry.addOrUpdateAccessory(lightDevice());
+    await registry.updateAccessoryState(lightDevice());
+    await registry.pruneStaleAccessories();
+    // Nothing should throw, and no state should be tracked.
+    assert.equal(registry.getStatus('light_1'), undefined);
+});
+
+test('addOrUpdateAccessory: register → pending → settled → registered', async () => {
+    const { api, registered } = makeApi();
+    const registry = new MatterAccessoryRegistry(api, silentLog(), () => undefined);
+    await registry.addOrUpdateAccessory(lightDevice());
+    assert.equal(registered.length, 1);
+    assert.equal(registry.getStatus('light_1'), 'pending');
+    await delay(2100); // > MATTER_REGISTER_SETTLE_MS
+    assert.equal(registry.getStatus('light_1'), 'registered');
+});
+
+test('status updates received during the settle window are queued, not pushed', async () => {
+    const { api, updates } = makeApi();
+    const registry = new MatterAccessoryRegistry(api, silentLog(), () => undefined);
+    await registry.addOrUpdateAccessory(lightDevice('light_2'));
+    assert.equal(registry.getStatus('light_2'), 'pending');
+    assert.equal(updates.length, 0);
+    await registry.updateAccessoryState({ ...lightDevice('light_2'), status: { on: false, dimmable: false } });
+    assert.equal(updates.length, 0, 'updateAccessoryState must not be called during settle');
+    assert.equal(registry.getPendingCount('light_2'), 1, 'state should be queued');
+});
+
+test('queued updates are flushed after the settle window', async () => {
+    const { api, updates } = makeApi();
+    const registry = new MatterAccessoryRegistry(api, silentLog(), () => undefined);
+    await registry.addOrUpdateAccessory(lightDevice('light_3'));
+    await registry.updateAccessoryState({ ...lightDevice('light_3'), status: { on: false, dimmable: false } });
+    assert.equal(updates.length, 0);
+    await delay(2100);
+    assert.ok(updates.length >= 1, 'queued update should be flushed after settle');
+    assert.equal(updates[0].uuid, 'light_3');
+    assert.equal(updates[0].clusterName, 'onOff');
+    assert.deepEqual(updates[0].attributes, { onOff: false });
+});
+
+test('queue dedupes by (clusterName, partId): only latest payload is kept', async () => {
+    const { api, updates } = makeApi();
+    const registry = new MatterAccessoryRegistry(api, silentLog(), () => undefined);
+    await registry.addOrUpdateAccessory(lightDevice('light_4'));
+    // Three updates for the same cluster — only the last one should remain queued
+    await registry.updateAccessoryState({ ...lightDevice('light_4'), status: { on: false, dimmable: false } });
+    await registry.updateAccessoryState({ ...lightDevice('light_4'), status: { on: true, dimmable: false } });
+    await registry.updateAccessoryState({ ...lightDevice('light_4'), status: { on: false, dimmable: false } });
+    assert.equal(registry.getPendingCount('light_4'), 1);
+    await delay(2100);
+    const onOffUpdates = updates.filter((u) => u.uuid === 'light_4' && u.clusterName === 'onOff');
+    assert.equal(onOffUpdates.length, 1);
+    assert.deepEqual(onOffUpdates[0].attributes, { onOff: false });
+});
+
+test('post-settle: updates are pushed immediately', async () => {
+    const { api, updates } = makeApi();
+    const registry = new MatterAccessoryRegistry(api, silentLog(), () => undefined);
+    await registry.addOrUpdateAccessory(lightDevice('light_5'));
+    await delay(2100); // settle
+    updates.length = 0;
+    await registry.updateAccessoryState({ ...lightDevice('light_5'), status: { on: false, dimmable: false } });
+    assert.equal(updates.length, 1);
+    assert.deepEqual(updates[0].attributes, { onOff: false });
+});
+
+test('thermostat: registers as Thermostat when matter accepts it', async () => {
+    const { api, registered } = makeApi();
+    const registry = new MatterAccessoryRegistry(api, silentLog(), () => undefined);
+    await registry.addOrUpdateAccessory(thermostatDevice('thermostat_50'));
+    await delay(2100);
+    assert.equal(registry.getStatus('thermostat_50'), 'registered');
+    assert.equal(registered[0].deviceType._t, 'Thermostat');
+});
+
+test('thermostat: falls back to TemperatureSensor when matter rejects the Thermostat', async () => {
+    let rejectedOnce = false;
+    const { api, registered } = makeApi({
+        registerImpl: (acc) => {
+            if (!rejectedOnce && acc.deviceType._t === 'Thermostat') {
+                rejectedOnce = true;
+                return 'throw';
+            }
+            return undefined;
+        },
+    });
+    const registry = new MatterAccessoryRegistry(api, silentLog(), () => undefined);
+    await registry.addOrUpdateAccessory(thermostatDevice('thermostat_60'));
+    // After failure, fallback should have been registered
+    assert.equal(registered.length, 1, 'first attempt failed, fallback was retried with TemperatureSensor');
+    assert.equal(registered[0].deviceType._t, 'TemperatureSensor');
+    await delay(2100);
+    assert.equal(registry.getStatus('thermostat_60'), 'registered');
+});
+
+test('thermostat fallback: state updates go to temperatureMeasurement, not thermostat cluster', async () => {
+    let rejectedOnce = false;
+    const { api, updates } = makeApi({
+        registerImpl: (acc) => {
+            if (!rejectedOnce && acc.deviceType._t === 'Thermostat') {
+                rejectedOnce = true;
+                return 'throw';
+            }
+        },
+    });
+    const registry = new MatterAccessoryRegistry(api, silentLog(), () => undefined);
+    await registry.addOrUpdateAccessory(thermostatDevice('thermostat_70'));
+    await delay(2100);
+    updates.length = 0;
+    await registry.updateAccessoryState(thermostatDevice('thermostat_70', { currentTemperature: 19.5 }));
+    assert.equal(updates.length, 1);
+    assert.equal(updates[0].clusterName, 'temperatureMeasurement');
+    assert.equal(updates[0].attributes.measuredValue, 1950);
+});
+
+test('failed device: no further attempts, no log spam', async () => {
+    const { api, registered } = makeApi({
+        registerImpl: () => 'throw',
+    });
+    const registry = new MatterAccessoryRegistry(api, silentLog(), () => undefined);
+    // Use a non-thermostat device (no fallback) to test the "failed" terminal state
+    await registry.addOrUpdateAccessory(lightDevice('light_99'));
+    assert.equal(registry.getStatus('light_99'), 'failed');
+    const callsAfterFail = registered.length;
+    // Subsequent updates must not retry
+    await registry.updateAccessoryState(lightDevice('light_99'));
+    await registry.addOrUpdateAccessory(lightDevice('light_99'));
+    assert.equal(registered.length, callsAfterFail, 'no further register attempts after failure');
+});
+
+test('prune: unregisters devices no longer present in discovery cycle', async () => {
+    const { api, unregistered } = makeApi();
+    const registry = new MatterAccessoryRegistry(api, silentLog(), () => undefined);
+    registry.startDiscoveryCycle();
+    await registry.addOrUpdateAccessory(lightDevice('light_a'));
+    await registry.addOrUpdateAccessory(lightDevice('light_b'));
+    await delay(2100); // settle both
+
+    // New cycle — only light_a is rediscovered
+    registry.startDiscoveryCycle();
+    await registry.addOrUpdateAccessory(lightDevice('light_a'));
+    await registry.pruneStaleAccessories();
+
+    assert.deepEqual(unregistered, ['light_b']);
+    assert.equal(registry.getStatus('light_b'), undefined);
+});

--- a/test/matter-accessory-registry.test.js
+++ b/test/matter-accessory-registry.test.js
@@ -105,6 +105,9 @@ function delay(ms) {
     return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+const SETTLE_AND_UPDATE_FLUSH_MS = 7200;
+const FALLBACK_SETTLE_AND_UPDATE_FLUSH_MS = 9400;
+
 // ---------------------------------------------------------------------------
 
 test('does not crash when api.matter is undefined', async () => {
@@ -150,7 +153,7 @@ test('queued updates are flushed after the settle window', async () => {
     await registry.addOrUpdateAccessory(lightDevice('light_3'));
     await registry.updateAccessoryState({ ...lightDevice('light_3'), status: { on: false, dimmable: false } });
     assert.equal(updates.length, 0);
-    await delay(2100);
+    await delay(SETTLE_AND_UPDATE_FLUSH_MS);
     assert.ok(updates.length >= 1, 'queued update should be flushed after settle');
     assert.equal(updates[0].uuid, 'light_3');
     assert.equal(updates[0].clusterName, 'onOff');
@@ -166,7 +169,7 @@ test('queue dedupes by (clusterName, partId): only latest payload is kept', asyn
     await registry.updateAccessoryState({ ...lightDevice('light_4'), status: { on: true, dimmable: false } });
     await registry.updateAccessoryState({ ...lightDevice('light_4'), status: { on: false, dimmable: false } });
     assert.equal(registry.getPendingCount('light_4'), 1);
-    await delay(2100);
+    await delay(SETTLE_AND_UPDATE_FLUSH_MS);
     const onOffUpdates = updates.filter((u) => u.uuid === 'light_4' && u.clusterName === 'onOff');
     assert.equal(onOffUpdates.length, 1);
     assert.deepEqual(onOffUpdates[0].attributes, { onOff: false });
@@ -226,7 +229,7 @@ test('thermostat: async missing registration falls back before state updates', a
     const registry = new MatterAccessoryRegistry(api, silentLog(), () => undefined);
     await registry.addOrUpdateAccessory(thermostatDevice('thermostat_async_missing'));
     await registry.updateAccessoryState(thermostatDevice('thermostat_async_missing', { currentTemperature: 19.5 }));
-    await delay(4300);
+    await delay(FALLBACK_SETTLE_AND_UPDATE_FLUSH_MS);
 
     assert.equal(registry.getStatus('thermostat_async_missing'), 'registered');
     assert.equal(registered[0].deviceType._t, 'Thermostat');

--- a/test/matter-accessory-registry.test.js
+++ b/test/matter-accessory-registry.test.js
@@ -43,7 +43,15 @@ function makeApi({ registerImpl, updateImpl, unregisterImpl } = {}) {
                 } else {
                     queryable.add(a.UUID);
                 }
-                registered.push({ UUID: a.UUID, displayName: a.displayName, deviceType: a.deviceType });
+                registered.push({
+                    UUID: a.UUID,
+                    displayName: a.displayName,
+                    manufacturer: a.manufacturer,
+                    model: a.model,
+                    serialNumber: a.serialNumber,
+                    firmwareRevision: a.firmwareRevision,
+                    deviceType: a.deviceType,
+                });
             }
         },
         updatePlatformAccessories: async (accessories) => {
@@ -131,11 +139,11 @@ test('addOrUpdateAccessory: register → pending → settled → registered', as
     assert.equal(registry.getStatus('light_1'), 'pending');
     await delay(2100); // > MATTER_REGISTER_SETTLE_MS
     assert.equal(registry.getStatus('light_1'), 'registered');
-    assert.equal(metadataUpdates.length, 1);
-    assert.equal(metadataUpdates[0].manufacturer, 'Ksenia');
-    assert.equal(metadataUpdates[0].model, 'Lares4 light');
-    assert.equal(metadataUpdates[0].serialNumber, 'light_1');
-    assert.match(metadataUpdates[0].firmwareRevision, /^\d+\.\d+\.\d+$/);
+    assert.equal(metadataUpdates.length, 0, 'must not call updatePlatformAccessories because it drops endpoints in HB2');
+    assert.equal(registered[0].manufacturer, 'Ksenia');
+    assert.equal(registered[0].model, 'Lares4 light');
+    assert.equal(registered[0].serialNumber, 'light_1');
+    assert.match(registered[0].firmwareRevision, /^\d+\.\d+\.\d+$/);
 });
 
 test('status updates received during the settle window are queued, not pushed', async () => {
@@ -241,7 +249,7 @@ test('thermostat: async missing registration falls back before state updates', a
     assert.equal(updates[0].attributes.measuredValue, 1950);
 });
 
-test('rediscovery refreshes cached Matter identity metadata when display name changes', async () => {
+test('rediscovery updates in-memory Matter identity without updatePlatformAccessories', async () => {
     const { api, metadataUpdates } = makeApi();
     const registry = new MatterAccessoryRegistry(api, silentLog(), () => undefined);
     await registry.addOrUpdateAccessory(lightDevice('light_meta'));
@@ -255,11 +263,7 @@ test('rediscovery refreshes cached Matter identity metadata when display name ch
         ...lightDevice('light_meta', { on: false }),
         name: 'Luce Sala',
     });
-    assert.equal(metadataUpdates.length, 1);
-    assert.equal(metadataUpdates[0].displayName, 'Luce Sala');
-    assert.equal(metadataUpdates[0].manufacturer, 'Ksenia');
-    assert.equal(metadataUpdates[0].model, 'Lares4 light');
-    assert.equal(metadataUpdates[0].serialNumber, 'light_meta');
+    assert.equal(metadataUpdates.length, 0, 'metadata changes must not overwrite Homebridge internal endpoint state');
 });
 
 test('thermostat fallback: state updates go to temperatureMeasurement, not thermostat cluster', async () => {

--- a/test/matter-thermostat-mapper.test.js
+++ b/test/matter-thermostat-mapper.test.js
@@ -1,0 +1,171 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    toMatterTemperatureCelsius,
+    fromMatterTemperatureCelsius,
+    clampMatterTemperature,
+    domainModeToMatterSystemMode,
+    getThermostatPresetWorkaroundAttributes,
+    thermostatSupportsCooling,
+    buildThermostatMatterState,
+    DEFAULT_HEATING_SETPOINT_C,
+    DEFAULT_DEADBAND_C,
+    TEMP_ABS_MIN_CENTI,
+    TEMP_ABS_MAX_CENTI,
+    CONTROL_SEQ_HEATING_ONLY,
+    CONTROL_SEQ_COOLING_AND_HEATING,
+    SYSTEM_MODE_OFF,
+    SYSTEM_MODE_HEAT,
+    SYSTEM_MODE_COOL,
+    SYSTEM_MODE_AUTO,
+} = require('../dist/platform/matter-thermostat-mapper.js');
+
+test('toMatterTemperatureCelsius: numeric values', () => {
+    assert.equal(toMatterTemperatureCelsius(22.5), 2250);
+    assert.equal(toMatterTemperatureCelsius(20), 2000);
+    assert.equal(toMatterTemperatureCelsius(0), 0);
+    assert.equal(toMatterTemperatureCelsius(-5), -500);
+});
+
+test('toMatterTemperatureCelsius: numeric strings', () => {
+    assert.equal(toMatterTemperatureCelsius('21'), 2100);
+    assert.equal(toMatterTemperatureCelsius('22.5'), 2250);
+});
+
+test('toMatterTemperatureCelsius: invalid inputs use fallback', () => {
+    assert.equal(toMatterTemperatureCelsius(null, 20), 2000);
+    assert.equal(toMatterTemperatureCelsius(undefined, 20), 2000);
+    assert.equal(toMatterTemperatureCelsius(NaN, 20), 2000);
+    assert.equal(toMatterTemperatureCelsius('not a number', 21), 2100);
+});
+
+test('fromMatterTemperatureCelsius: round-trip', () => {
+    assert.equal(fromMatterTemperatureCelsius(2250), 22.5);
+    assert.equal(fromMatterTemperatureCelsius(toMatterTemperatureCelsius(18.3)), 18.3);
+});
+
+test('clampMatterTemperature: bounds are enforced', () => {
+    assert.equal(clampMatterTemperature(5000, -27000, 10000), 5000);
+    assert.equal(clampMatterTemperature(-30000, -27000, 10000), -27000);
+    assert.equal(clampMatterTemperature(15000, -27000, 10000), 10000);
+    assert.equal(clampMatterTemperature(NaN, -27000, 10000), -27000);
+});
+
+test('domainModeToMatterSystemMode: enum values match Matter spec §4.3.7.32', () => {
+    assert.equal(domainModeToMatterSystemMode('off'), SYSTEM_MODE_OFF);
+    assert.equal(domainModeToMatterSystemMode('heat'), SYSTEM_MODE_HEAT);
+    assert.equal(domainModeToMatterSystemMode('cool'), SYSTEM_MODE_COOL);
+    assert.equal(domainModeToMatterSystemMode('auto'), SYSTEM_MODE_AUTO);
+    assert.equal(domainModeToMatterSystemMode(undefined), SYSTEM_MODE_OFF);
+});
+
+test('getThermostatPresetWorkaroundAttributes: ships exactly one valid preset slot', () => {
+    const wa = getThermostatPresetWorkaroundAttributes();
+    assert.equal(wa.numberOfPresets, 1);
+    assert.ok(Array.isArray(wa.presetTypes));
+    assert.equal(wa.presetTypes.length, 1);
+    assert.equal(wa.presetTypes[0].presetScenario, 1);             // Occupied
+    assert.equal(wa.presetTypes[0].numberOfPresets, 1);
+    assert.equal(wa.presetTypes[0].presetTypeFeatures, 0);
+});
+
+test('thermostatSupportsCooling: detects Italian + English naming', () => {
+    assert.equal(thermostatSupportsCooling({ name: 'Raffrescamento Sala' }), true);
+    assert.equal(thermostatSupportsCooling({ name: 'Raffreddamento Camera' }), true);
+    assert.equal(thermostatSupportsCooling({ name: 'Climatizzazione Ufficio' }), true);
+    assert.equal(thermostatSupportsCooling({ name: 'Cooling Living' }), true);
+    assert.equal(thermostatSupportsCooling({ name: 'Riscaldamento Bagno' }), false);
+    assert.equal(thermostatSupportsCooling({ name: 'Heating Office' }), false);
+    assert.equal(thermostatSupportsCooling({ name: undefined }), false);
+});
+
+test('buildThermostatMatterState: heating-only thermostat', () => {
+    const device = {
+        id: 'thermostat_18',
+        name: 'Riscaldamento Sala',
+        type: 'thermostat',
+        currentTemperature: 21.2,
+        targetTemperature: 20,
+        mode: 'heat',
+        status: {},
+    };
+    const { base, schemaInvariants } = buildThermostatMatterState(device);
+
+    assert.equal(base.localTemperature, 2120);
+    assert.equal(base.occupiedHeatingSetpoint, 2000);
+    assert.equal(base.systemMode, SYSTEM_MODE_HEAT);
+    assert.equal(schemaInvariants.controlSequenceOfOperation, CONTROL_SEQ_HEATING_ONLY);
+    assert.ok(schemaInvariants.minHeatSetpointLimit >= TEMP_ABS_MIN_CENTI);
+    assert.ok(schemaInvariants.maxHeatSetpointLimit <= TEMP_ABS_MAX_CENTI);
+    assert.equal(schemaInvariants.minSetpointDeadBand, DEFAULT_DEADBAND_C * 10);
+    assert.equal(schemaInvariants.numberOfPresets, 1);
+    assert.equal(schemaInvariants.presetTypes.length, 1);
+});
+
+test('buildThermostatMatterState: cooling-capable thermostat exposes both setpoints', () => {
+    const device = {
+        id: 'thermostat_34',
+        name: 'Raffrescamento Sala',
+        type: 'thermostat',
+        currentTemperature: 24,
+        targetTemperature: 23,
+        mode: 'cool',
+        status: {},
+    };
+    const { base, schemaInvariants } = buildThermostatMatterState(device);
+
+    assert.equal(schemaInvariants.controlSequenceOfOperation, CONTROL_SEQ_COOLING_AND_HEATING);
+    assert.equal(base.systemMode, SYSTEM_MODE_COOL);
+    assert.ok(typeof base.occupiedCoolingSetpoint === 'number');
+    assert.ok(base.occupiedCoolingSetpoint - base.occupiedHeatingSetpoint >= schemaInvariants.minSetpointDeadBand * 10);
+});
+
+test('buildThermostatMatterState: heating-only coerces stale cool/auto mode to heat', () => {
+    const device = {
+        id: 'thermostat_x',
+        name: 'Riscaldamento Studio',
+        type: 'thermostat',
+        currentTemperature: 19,
+        targetTemperature: 20,
+        mode: 'auto', // stale — Lares4 model leaked an auto mode for a heating-only device
+        status: {},
+    };
+    const { base, schemaInvariants } = buildThermostatMatterState(device);
+    assert.equal(schemaInvariants.controlSequenceOfOperation, CONTROL_SEQ_HEATING_ONLY);
+    assert.equal(base.systemMode, SYSTEM_MODE_HEAT);
+});
+
+test('buildThermostatMatterState: NaN / null current temp falls back to default', () => {
+    const device = {
+        id: 'thermostat_y',
+        name: 'Riscaldamento Bagno',
+        type: 'thermostat',
+        currentTemperature: null,
+        targetTemperature: NaN,
+        mode: 'heat',
+        status: {},
+    };
+    const { base } = buildThermostatMatterState(device);
+    assert.equal(typeof base.localTemperature, 'number');
+    assert.equal(base.occupiedHeatingSetpoint, DEFAULT_HEATING_SETPOINT_C * 100);
+});
+
+test('buildThermostatMatterState: deadband invariant always holds (cooling - heating >= deadband)', () => {
+    // Edge case: heating setpoint at top of range — cooling must shift up too
+    const device = {
+        id: 'thermostat_edge',
+        name: 'Raffrescamento Edge',
+        type: 'thermostat',
+        currentTemperature: 29,
+        targetTemperature: 30, // at max heating
+        mode: 'heat',
+        status: {},
+    };
+    const { base, schemaInvariants } = buildThermostatMatterState(device);
+    const deadbandCenti = schemaInvariants.minSetpointDeadBand * 10;
+    assert.ok(
+        base.occupiedCoolingSetpoint - base.occupiedHeatingSetpoint >= deadbandCenti,
+        `cooling(${base.occupiedCoolingSetpoint}) - heating(${base.occupiedHeatingSetpoint}) must be >= deadband(${deadbandCenti})`,
+    );
+});

--- a/test/matter-thermostat-mapper.test.js
+++ b/test/matter-thermostat-mapper.test.js
@@ -67,7 +67,7 @@ test('getThermostatPresetWorkaroundAttributes: ships exactly one valid preset sl
     assert.equal(wa.presetTypes.length, 1);
     assert.equal(wa.presetTypes[0].presetScenario, 1);             // Occupied
     assert.equal(wa.presetTypes[0].numberOfPresets, 1);
-    assert.equal(wa.presetTypes[0].presetTypeFeatures, 0);
+    assert.deepEqual(wa.presetTypes[0].presetTypeFeatures, { automatic: false, supportsNames: false });
 });
 
 test('thermostatSupportsCooling: detects Italian + English naming', () => {

--- a/test/plugin-version.test.js
+++ b/test/plugin-version.test.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { PLUGIN_VERSION, PLUGIN_VERSION_RAW } = require('../dist/plugin-version');
+const pkg = require('../package.json');
+
+test('PLUGIN_VERSION_RAW matches package.json version exactly', () => {
+    assert.equal(PLUGIN_VERSION_RAW, pkg.version);
+});
+
+test('PLUGIN_VERSION is HAP/Matter-compliant semver (M.m.p, no suffix)', () => {
+    assert.match(PLUGIN_VERSION, /^\d+\.\d+\.\d+$/);
+});
+
+test('PLUGIN_VERSION is a prefix of PLUGIN_VERSION_RAW', () => {
+    assert.ok(
+        PLUGIN_VERSION_RAW.startsWith(PLUGIN_VERSION),
+        `Expected "${PLUGIN_VERSION_RAW}" to start with "${PLUGIN_VERSION}"`,
+    );
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
         "rootDir": "./src",
         "strict": true,
         "esModuleInterop": true,
+        "resolveJsonModule": true,
         "skipLibCheck": true,
         "forceConsistentCasingInFileNames": true,
         "declaration": true,


### PR DESCRIPTION
## Summary

Promote the Homebridge 2.0 + Matter compatibility track to stable.

- Migrates from HAP-only to native Matter accessory registration via `api.matter.registerPlatformAccessories` (HAP path preserved as fallback).
- Production-validated on a Matter-only child bridge (`hap=false`) with 81 Lares4 accessories in Apple Home: thermostats register as proper `Thermostat` devices (setpoint + mode), sensors show fresh values at startup, scenarios and gate behave as momentary `OnOffSwitch` with auto-off, cache-resume skips redundant re-registration at every restart.
- Includes the full 2.1.0-rc.0 → rc.12 cycle (16 commits). The final rc.12 → 2.1.0 bump is the head of this branch.

See CHANGELOG.md for the per-version breakdown.

## Test plan

- [x] `npm run verify` (max-lines + strict tsc + 97 unit tests) green locally.
- [x] CI on `feat/homebridge2-matter-compatibility` green for rc.12.
- [x] Production deploy on `smarthome-homebridge-1` (Docker, HB 2.0.2, matter.js 0.17-alpha) — verified in Apple Home: thermostats, sensors, covers, zones, lights, scenarios, gate all working.
- [ ] After merge: tag `v2.1.0` on `main` to trigger the `Release Publish` GitHub Action (npm publish with `latest` tag).