### PR TITLE
fix(matter): trust accessory cache on resume (v2.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.1] - 2026-05-19
+
+### Fixed (Matter)
+
+- Cache-resume path now trusts the Homebridge accessory cache instead of waiting up to 10s on `getAccessoryState` to confirm the Matter endpoint is ready. With ~80 cached accessories the matter.js endpoint restore is staggered and the previous behaviour produced spurious `[Matter] cache resume probe timed out … re-registering` warnings and slow boot. The new path does a brief best-effort probe (2s) but always marks the accessory `registered`; state updates still flow through the queue, which absorbs transient endpoint-not-ready errors. No effect on Apple Home rooms/associations (same UUID, no unregister).
+- Bumped the default register-probe timeout from 10s to 30s for the genuine fresh-register path, so first-time accessory creation on slow systems doesn't fall back to recovery prematurely. Override via `KLARES4_MATTER_REGISTER_TIMEOUT_MS`.
+
 ## [2.1.0] - 2026-05-19
 
 Stable release of the Homebridge 2.0 + Matter compatibility track. Aggregates

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "homebridge-plugin-klares4",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "description": "Plugin completo per sistemi Ksenia Lares4 - Zone, Luci, Tapparelle, Termostati, Sensori",
     "main": "dist/index.js",
     "scripts": {

--- a/src/platform/matter-accessory-registry.ts
+++ b/src/platform/matter-accessory-registry.ts
@@ -184,19 +184,27 @@ export class MatterAccessoryRegistry {
         const reg = this.registrations.get(uuid);
         if (!reg || reg.status !== 'pending') return;
 
+        // Cache-resume path: trust the Homebridge accessory cache. The Matter
+        // storage holds the endpoint — even if matter.js hasn't restored it yet
+        // at the moment we probe, it will, and our updates go through the
+        // state-update queue anyway (which retries naturally on first failure).
+        // We do a quick best-effort probe to surface the rare "endpoint really
+        // gone" case, but never re-register on a soft timeout.
+        if (skipRegister) {
+            await probeUntilQueryable(this.api, this.log, (e) => this.fmtErr(e), reg, {
+                timeoutMs: 2000,
+                initialDelayMs: 200,
+                maxDelayMs: 500,
+            });
+            reg.status = 'registered';
+            reg.registeredAt = Date.now();
+            this.stateUpdateQueue.markReadyAfterBootstrap(reg);
+            this.stateUpdateQueue.scheduleFlush(uuid);
+            return;
+        }
+
         const queryable = await probeUntilQueryable(this.api, this.log, (e) => this.fmtErr(e), reg);
         if (!queryable) {
-            if (skipRegister) {
-                // Cache resume failed — endpoint was lost from storage. Fall back to full register.
-                this.log.warn(`[Matter] cache resume probe timed out for ${reg.displayName}; re-registering.`);
-                try {
-                    await this.api.matter!.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [reg.matterAccessory]);
-                    void this.completeRegistration(uuid);
-                } catch (err) {
-                    await this.handleRegisterFailure(reg.matterAccessory.context.device as KseniaDevice, err);
-                }
-                return;
-            }
             await handleMissingRegisteredAccessory(reg, this.recoveryDeps());
             return;
         }

--- a/src/platform/matter-register-probe.ts
+++ b/src/platform/matter-register-probe.ts
@@ -12,7 +12,7 @@ import { isMatterAccessoryQueryable } from './matter-registration-recovery';
  * Returns `true` if the endpoint became queryable, `false` if the timeout
  * elapsed first (caller decides recovery).
  */
-const DEFAULT_TIMEOUT_MS = 10000;
+const DEFAULT_TIMEOUT_MS = 30000;
 const DEFAULT_POLL_INITIAL_MS = 250;
 const DEFAULT_POLL_MAX_MS = 1000;
 


### PR DESCRIPTION
## Summary

Eliminates the spurious \`[Matter] cache resume probe timed out … re-registering\` warnings observed at startup on the production deployment (~80 cached accessories).

- Cache-resume now trusts the Homebridge accessory cache. A brief 2s best-effort probe is still performed, but the accessory is always marked \`registered\` afterwards — state updates flow through the queue, which absorbs transient \`endpoint not ready\` errors with natural retries.
- Fresh-register probe timeout raised from 10s to 30s (env override \`KLARES4_MATTER_REGISTER_TIMEOUT_MS\` unchanged).
- No effect on Apple Home rooms/automations: same UUID, no \`unregisterPlatformAccessories\` involved.

## Test plan

- [x] \`npm run verify\` green locally (97 tests).
- [ ] Production: zero \`cache resume probe timed out\` log lines after restart; Apple Home rooms preserved.