### PR TITLE
fix(matter): scenarios visible on Alexa via OnOffOutlet device type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.4-rc.1] - 2026-05-24
+
+### Fixed — Matter scenarios visible on Alexa (and re-tappable on Apple Home)
+
+- **Scenarios were invisible in the Alexa app and stuck "ON" forever in Apple Home.** The momentary-switch mapper (used for `scenario` and `gate` devices) registered them with Matter device type `OnOffSwitch` (0x0103). Per Matter spec, `OnOffSwitch` is a **client** device — a wall switch that emits commands via binding, not a controllable endpoint. Apple Home is permissive and exposed it anyway, but Alexa follows the spec strictly and silently drops it from the device list. Combined with the existing momentary-trigger semantics (no real "off"), the result was: invisibility on Alexa, and on Apple Home the cluster `onOff` value latched to `true` so a second tap was suppressed by the controller before reaching the panel. Fix in [`src/platform/matter-device-mapper.ts`](src/platform/matter-device-mapper.ts): `mapMomentarySwitch` now uses `deviceTypes.OnOffOutlet` (Matter `OnOffPlugInUnit`, 0x010A) — a controllable server device that every ecosystem (Apple Home, Alexa, Google Home, SmartThings) imports as a tappable plug. The auto-off path (`scheduleMomentaryAutoOff`, default 500 ms, configurable via `scenarioAutoOffDelay`) continues to reset the cluster state so subsequent taps re-trigger the scenario. Visual effect: in Apple Home the scenario icon changes from "switch" to "outlet"; in Alexa scenarios now appear under **Plugs** and respond to voice commands ("Alexa, accendi Mood Cena"). Regression coverage: new test file [`test/matter-device-mapper.test.js`](test/matter-device-mapper.test.js) asserts the device type, the auto-off scheduling and that an auto-off rejection (e.g. endpoint not yet ready) is swallowed without surfacing to the controller.
+
 ## [2.1.3] - 2026-05-23
 
 Stable release of the **`2.1.3-rc.1` … `2.1.3-rc.7`** cycle, validated on a

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "homebridge-plugin-klares4",
-    "version": "2.1.3",
+    "version": "2.1.4-rc.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "homebridge-plugin-klares4",
-            "version": "2.1.3",
+            "version": "2.1.4-rc.1",
             "license": "MIT",
             "dependencies": {
                 "mqtt": "^5.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "homebridge-plugin-klares4",
-    "version": "2.1.3",
+    "version": "2.1.4-rc.1",
     "description": "Plugin completo per sistemi Ksenia Lares4 - Zone, Luci, Tapparelle, Termostati, Sensori",
     "main": "dist/index.js",
     "scripts": {

--- a/src/platform/matter-device-mapper.ts
+++ b/src/platform/matter-device-mapper.ts
@@ -215,9 +215,14 @@ function mapZone(device: KseniaZone, deps: MapperDeps): MatterAccessory {
 }
 
 function mapMomentarySwitch(device: KseniaDevice, trigger: () => Promise<void>, deps: MapperDeps): MatterAccessory {
+    // OnOffOutlet (= Matter OnOffPlugInUnit, 0x010A) instead of OnOffSwitch (0x0103).
+    // OnOffSwitch is a Matter *client* device (a wall switch sending commands via binding) —
+    // Alexa follows the spec and refuses to import it as a controllable accessory, leaving
+    // scenarios invisible. OnOffOutlet is a controllable server device that every ecosystem
+    // (Apple Home, Alexa, Google) exposes as a tappable plug.
     return {
         ...baseFields(device, deps.log),
-        deviceType: deps.api.matter!.deviceTypes.OnOffSwitch,
+        deviceType: deps.api.matter!.deviceTypes.OnOffOutlet,
         clusters: { onOff: { onOff: false } },
         handlers: { onOff: {
             on: async () => { await trigger(); scheduleMomentaryAutoOff(device.id, deps); },

--- a/test/matter-device-mapper.test.js
+++ b/test/matter-device-mapper.test.js
@@ -1,0 +1,114 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { deviceToMatterAccessory } = require('../dist/platform/matter-device-mapper.js');
+
+const fakeDeviceTypes = {
+    OnOffLight: { _t: 'OnOffLight' },
+    DimmableLight: { _t: 'DimmableLight' },
+    WindowCovering: { _t: 'WindowCovering' },
+    Thermostat: { _t: 'Thermostat' },
+    TemperatureSensor: { _t: 'TemperatureSensor' },
+    HumiditySensor: { _t: 'HumiditySensor' },
+    LightSensor: { _t: 'LightSensor' },
+    MotionSensor: { _t: 'MotionSensor' },
+    ContactSensor: { _t: 'ContactSensor' },
+    OnOffSwitch: { _t: 'OnOffSwitch' },
+    OnOffOutlet: { _t: 'OnOffOutlet' },
+};
+
+function silentLog() {
+    return { info: () => {}, warn: () => {}, debug: () => {}, error: () => {} };
+}
+
+function makeApi({ updateImpl } = {}) {
+    const updates = [];
+    return {
+        api: {
+            matter: {
+                deviceTypes: fakeDeviceTypes,
+                updateAccessoryState: async (uuid, clusterName, attributes, partId) => {
+                    updates.push({ uuid, clusterName, attributes, partId });
+                    if (updateImpl) return updateImpl({ uuid, clusterName, attributes, partId });
+                },
+            },
+        },
+        updates,
+    };
+}
+
+function makeWsClient() {
+    const calls = { triggerScenario: [], toggleGate: [] };
+    return {
+        client: {
+            triggerScenario: async (id) => { calls.triggerScenario.push(id); },
+            toggleGate: async (id) => { calls.toggleGate.push(id); },
+        },
+        calls,
+    };
+}
+
+test('mapScenario exposes deviceType OnOffOutlet (not OnOffSwitch)', () => {
+    const { api } = makeApi();
+    const { client } = makeWsClient();
+    const acc = deviceToMatterAccessory(
+        { id: 'scenario_1', name: 'Mood Cena', type: 'scenario' },
+        { api, log: silentLog(), getWsClient: () => client },
+    );
+    assert.ok(acc, 'mapper must return an accessory');
+    assert.equal(acc.deviceType, fakeDeviceTypes.OnOffOutlet, 'scenarios must be OnOffOutlet for Alexa compatibility');
+    assert.notEqual(acc.deviceType, fakeDeviceTypes.OnOffSwitch, 'OnOffSwitch is a Matter client device and breaks Alexa');
+    assert.deepEqual(acc.clusters.onOff, { onOff: false });
+});
+
+test('mapGate also uses OnOffOutlet (shares the momentary switch helper)', () => {
+    const { api } = makeApi();
+    const { client } = makeWsClient();
+    const acc = deviceToMatterAccessory(
+        { id: 'gate_1', name: 'Cancello', type: 'gate' },
+        { api, log: silentLog(), getWsClient: () => client },
+    );
+    assert.ok(acc);
+    assert.equal(acc.deviceType, fakeDeviceTypes.OnOffOutlet);
+});
+
+test('scenario "on" handler triggers the scenario and schedules an auto-off updateAccessoryState', async () => {
+    const { api, updates } = makeApi();
+    const { client, calls } = makeWsClient();
+    const acc = deviceToMatterAccessory(
+        { id: 'scenario_42', name: 'Test', type: 'scenario' },
+        { api, log: silentLog(), getWsClient: () => client, momentaryAutoOffMs: 25 },
+    );
+    await acc.handlers.onOff.on();
+    assert.deepEqual(calls.triggerScenario, ['scenario_42'], 'trigger must fire immediately');
+    assert.equal(updates.length, 0, 'auto-off must be deferred (not synchronous)');
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    assert.equal(updates.length, 1, 'auto-off must fire exactly once after the delay');
+    assert.deepEqual(updates[0], { uuid: 'scenario_42', clusterName: 'onOff', attributes: { onOff: false }, partId: undefined });
+});
+
+test('scenario "off" handler is a no-op (momentary semantics)', async () => {
+    const { api, updates } = makeApi();
+    const { client, calls } = makeWsClient();
+    const acc = deviceToMatterAccessory(
+        { id: 'scenario_7', name: 'X', type: 'scenario' },
+        { api, log: silentLog(), getWsClient: () => client, momentaryAutoOffMs: 10 },
+    );
+    await acc.handlers.onOff.off();
+    assert.equal(calls.triggerScenario.length, 0, 'off must not trigger the scenario');
+    assert.equal(updates.length, 0, 'off must not schedule any state update');
+});
+
+test('auto-off rejection is swallowed: trigger already happened, controller must not see an error', async () => {
+    const { api } = makeApi({ updateImpl: () => { throw new Error('endpoint not ready'); } });
+    const { client, calls } = makeWsClient();
+    const acc = deviceToMatterAccessory(
+        { id: 'scenario_3', name: 'Y', type: 'scenario' },
+        { api, log: silentLog(), getWsClient: () => client, momentaryAutoOffMs: 5 },
+    );
+    await acc.handlers.onOff.on();
+    assert.deepEqual(calls.triggerScenario, ['scenario_3']);
+    // Give the scheduled auto-off time to run and reject internally.
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    // No assertion needed beyond "process did not crash with an unhandled rejection".
+});


### PR DESCRIPTION
## Summary

Fix two compound symptoms with one root cause:

- **Alexa**: scenarios (and gates) were **invisible** — not imported into the device list at all.
- **Apple Home**: scenarios appeared but the first tap latched the cluster \`onOff\` to \`true\`; the second tap was suppressed by the controller before reaching the panel, so the scenario could not be re-triggered without restarting the bridge.

Root cause: \`mapMomentarySwitch\` in [\`src/platform/matter-device-mapper.ts\`](src/platform/matter-device-mapper.ts) registered scenarios with Matter device type \`OnOffSwitch\` (0x0103). Per Matter spec §9.1 that is a **client** device — a wall switch that emits commands through binding, not a controllable endpoint. Alexa enforces the spec and drops it; Apple Home is permissive but the cluster state still latched.

## Fix

\`mapMomentarySwitch\` now uses \`deviceTypes.OnOffOutlet\` (Matter \`OnOffPlugInUnit\`, 0x010A), a controllable server device that every ecosystem (Apple Home, Alexa, Google, SmartThings) imports as a tappable plug. The existing auto-off path (\`scheduleMomentaryAutoOff\`, default 500ms, configurable via \`scenarioAutoOffDelay\`) is unchanged and continues to reset the cluster after each trigger so subsequent taps re-fire.

Only the momentary mapper is touched — no other device types, no HAP path changes, no \`@matter/node\` version change.

## User-visible effect

- **Apple Home**: scenario icons change from "switch" to "outlet"; second tap now re-triggers as expected.
- **Alexa**: scenarios appear under **Plugs** and respond to voice ("Alexa, accendi Mood Cena").

## Test plan

- [x] \`npm run verify\` (max-lines + tsc strict + tests + build): **154/154 pass**, new file \`matter-device-mapper.test.js\` (5 tests) verifies device type, auto-off scheduling, no-op off handler, and silent swallowing of auto-off rejections.
- [ ] **Manual on production container** (\`smarthome-homebridge-1\`) after \`2.1.4-rc.1\` publish:
  - [ ] Apple Home: tap a scenario (e.g. "Mood Cena") — it triggers, returns to OFF in ~500ms, second tap re-triggers.
  - [ ] Alexa app: Devices → Plugs → ~15 scenarios visible (excluded by config: ids \`14\`, \`17\`).
  - [ ] Voice: "Alexa, accendi Mood Cena" triggers the scenario.
  - [ ] Boot log shows the 15 scenarios registered without errors; no regression on lights/covers/sensors/thermostats.

## Release

Tag \`v2.1.4-rc.1\` will be pushed after merge; \`release-publish.yml\` will publish to npm under the \`rc\` dist-tag automatically.