### PR TITLE
fix(matter): priority-based collision suffix + abbreviated suffix table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.4-rc.3] - 2026-05-24
+
+### Changed — Matter name collisions: priority-based + abbreviated suffix
+
+- **Higher-priority device types now win the clean name.** Real-world Lares4 discovery emits `ZONES` before `MULTI_TYPES`, which on 2.1.4-rc.2 meant the contact-sensor zone took the clean label and the controllable cover ended up tagged. The `MatterNameRegistry` now compares Lares4 device types on collision: cover, light, thermostat, gate and scenario (priority 10) displace zone and sensor (priority 1). When a higher-priority device arrives second, the registry hands the clean name to the newcomer and queues the displaced uuid in a *pending renames* map (`consumePendingMatterRenames`) that `MatterAccessoryRegistry` drains after each successful register, triggering a metadata refresh on the displaced accessory so the controller sees the new ` - Sens.` suffix. Net effect on the production log: `Finestra Cucina (cover)` keeps the clean label, `Finestra Cucina (zone)` becomes `Finestra Cucina - Sens.`.
+- **Abbreviated suffixes avoid mid-word truncation.** rc.2 produced labels like `Finestra Matrimonia - Tapparella` (Matrimoniale chopped at 32-char limit). Suffix table is now: `zone/sensor → ' - Sens.'`, `cover → ' - Tapp.'`, `light → ' - Luce'`, `thermostat → ' - Term.'`, `scenario → ' - Scenario'`, `gate → ' - Cancello'`. Short enough that 27-char names fit without head truncation; pathological cases still truncate the head, never the suffix.
+- **Anti-redundancy is now root-based.** Names like `Tapparella Studio` (which already starts with the cover type) no longer receive a redundant `- Tapp.` suffix when colliding with a peer; the registry falls back to the uuid-derived 4-char tag. Same for `Termostato …` → `Term.`, `Sensore …` → `Sens.`.
+
+### Internal
+
+- New export `consumePendingMatterRenames()` in `matter-device-mapper.ts` so `MatterAccessoryRegistry` can drain displaced-name events without reaching into the module-level singleton directly.
+- `MatterNameRegistry` API additions: `consumePendingRenames()` returns and clears the pending-rename map. The `resolve` signature is unchanged.
+
 ## [2.1.4-rc.2] - 2026-05-24
 
 ### Changed — Matter accessory name sanitisation (allowlist + typed collision suffix)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "homebridge-plugin-klares4",
-    "version": "2.1.4-rc.2",
+    "version": "2.1.4-rc.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "homebridge-plugin-klares4",
-            "version": "2.1.4-rc.2",
+            "version": "2.1.4-rc.3",
             "license": "MIT",
             "dependencies": {
                 "mqtt": "^5.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "homebridge-plugin-klares4",
-    "version": "2.1.4-rc.2",
+    "version": "2.1.4-rc.3",
     "description": "Plugin completo per sistemi Ksenia Lares4 - Zone, Luci, Tapparelle, Termostati, Sensori",
     "main": "dist/index.js",
     "scripts": {

--- a/src/platform/matter-accessory-registry.ts
+++ b/src/platform/matter-accessory-registry.ts
@@ -3,7 +3,7 @@ import type { MatterAccessory } from 'homebridge';
 import type { KseniaDevice, KseniaThermostat } from '../types';
 import { PLUGIN_NAME, PLATFORM_NAME } from '../settings';
 import type { KseniaWebSocketClient } from '../websocket-client';
-import { deviceToMatterAccessory, mapThermostatAsTemperatureSensor } from './matter-device-mapper';
+import { deviceToMatterAccessory, mapThermostatAsTemperatureSensor, consumePendingMatterRenames } from './matter-device-mapper';
 import { buildStateUpdates } from './matter-state-updates';
 import {
     handleMissingRegisteredAccessory,
@@ -208,7 +208,30 @@ export class MatterAccessoryRegistry {
             await this.handleRegisterFailure(device, err);
             return;
         }
+        await this.applyPendingDisplacedRenames();
         void this.completeRegistration(device.id);
+    }
+
+    /**
+     * When a higher-priority device displaces a sensor/zone that previously
+     * owned the clean name, the sanitiser queues the displaced uuid here. For
+     * each one, re-run the mapper so the displayName picks up the typed-suffix
+     * candidate, and push the metadata refresh through `refreshAccessoryMetadata`.
+     */
+    private async applyPendingDisplacedRenames(): Promise<void> {
+        const pending = consumePendingMatterRenames();
+        if (pending.size === 0) return;
+        for (const uuid of pending.keys()) {
+            const reg = this.registrations.get(uuid);
+            if (!reg) continue;
+            const device = reg.matterAccessory.context.device as KseniaDevice | undefined;
+            if (!device) continue;
+            try {
+                await this.refreshAccessoryMetadata(device, reg);
+            } catch (err) {
+                this.log.debug(`[Matter] displaced-rename refresh failed for ${uuid}: ${this.fmtErr(err)}`);
+            }
+        }
     }
 
     private async completeRegistration(uuid: string): Promise<void> {

--- a/src/platform/matter-device-mapper.ts
+++ b/src/platform/matter-device-mapper.ts
@@ -22,6 +22,17 @@ import { buildThermostatHandlers } from './matter-thermostat-handlers';
 
 const matterNameRegistry = new MatterNameRegistry();
 
+/**
+ * Drain the typed-suffix collision queue. When a high-priority device (cover,
+ * light, thermostat, gate, scenario) displaces a previously-registered
+ * sensor/zone that was sharing the same sanitised name, the displaced uuid is
+ * queued here so the platform registry can refresh its matter metadata with
+ * the new ' - Sens.' / ' - <Tipo>' suffix.
+ */
+export function consumePendingMatterRenames(): Map<string, string> {
+    return matterNameRegistry.consumePendingRenames();
+}
+
 // Re-exports for legacy callers (registry pushStateUpdate, tests)
 export { toMatterTemperatureCelsius as toCentidegrees };
 export { buildThermostatMatterState };

--- a/src/platform/matter-name-sanitizer.ts
+++ b/src/platform/matter-name-sanitizer.ts
@@ -36,16 +36,6 @@ const BOUNDARY_RIGHT = /[^\p{L}\p{N}’]+$/u;
 
 /**
  * Sanitise a device name for use as a Matter accessory `displayName`.
- *
- * Pipeline:
- *  1. Replace `+` with ` e ` (human-readable expansion of "Inserisci A+B").
- *  2. Strip parentheses/brackets but keep their content.
- *  3. Replace every char outside the allowlist with a space.
- *  4. Collapse whitespace, trim.
- *  5. Trim non-allowed boundary chars (so first/last char satisfies HAP rule).
- *  6. Truncate to MAX_NAME_LENGTH, retrim boundary on the right.
- *  7. Empty result → `fallback` (default 'Device'), itself run through the
- *     same boundary trim to guarantee HomeKit compliance.
  */
 export function sanitizeMatterAccessoryName(name: string, fallback = 'Device'): string {
     const safe = clean(typeof name === 'string' ? name : '');
@@ -68,34 +58,55 @@ function clean(raw: string): string {
 
 /**
  * Italian, HomeKit-safe collision suffix per Lares4 device type.
- * Every value uses only characters from the allowlist above.
+ * Abbreviations chosen so even the longest sanitised name (32 chars) + suffix
+ * stays within the 32-char Matter limit when the head is itself reasonable.
+ * For pathologically long names the head is truncated, never the suffix.
  */
 const TYPE_SUFFIX: Record<string, string> = {
-    zone: 'Sensore',
-    sensor: 'Sensore',
-    cover: 'Tapparella',
+    zone: 'Sens.',
+    sensor: 'Sens.',
+    cover: 'Tapp.',
     light: 'Luce',
-    thermostat: 'Termostato',
+    thermostat: 'Term.',
     scenario: 'Scenario',
     gate: 'Cancello',
 };
 
+/**
+ * Priority: higher = retains the clean name on collision.
+ * User-controllable devices (cover, light, thermostat, gate, scenario)
+ * outrank passive sensors (zone, sensor) — so a "Finestra Cucina" cover
+ * keeps the clean label while the matching contact-sensor zone gets
+ * "Finestra Cucina - Sens.".
+ */
+const TYPE_PRIORITY: Record<string, number> = {
+    cover: 10,
+    light: 10,
+    thermostat: 10,
+    gate: 10,
+    scenario: 10,
+    zone: 1,
+    sensor: 1,
+};
+
+function priorityOf(deviceType: string | undefined): number {
+    if (!deviceType) return 0;
+    return TYPE_PRIORITY[deviceType] ?? 0;
+}
+
 const SUFFIX_SEPARATOR = ' - ';
 
-/**
- * Does `name` already mention `suffix` as a whole word?
- * Used to skip redundant collision tags like "Tapparella Studio - Tapparella".
- */
 function nameAlreadyMentions(name: string, suffix: string): boolean {
-    const pattern = new RegExp(`(^|\\s)${suffix}(\\s|$)`, 'iu');
+    // Treat the suffix as a *root*: strip any trailing "." so "Tapp." → "Tapp",
+    // and match it at any word boundary. This way "Tapparella Studio" is
+    // recognised as already mentioning "Tapp.", and "Termostato Sala" as
+    // already mentioning "Term.". Avoids redundant " - Tapp." / " - Term."
+    // tags on names that already describe their own type.
+    const root = suffix.replace(/\.$/, '');
+    const pattern = new RegExp(`\\b${root}`, 'iu');
     return pattern.test(name);
 }
 
-/**
- * Build a typed-suffix candidate, honouring the 32-char cap by truncating the
- * *name* part, never the suffix. Returns the candidate or `null` if the type
- * suffix is unknown or the original name already mentions the type.
- */
 function buildTypedSuffix(name: string, deviceType: string | undefined): string | null {
     if (!deviceType) return null;
     const suffix = TYPE_SUFFIX[deviceType];
@@ -110,11 +121,6 @@ function buildTypedSuffix(name: string, deviceType: string | undefined): string 
     return `${head}${tail}`;
 }
 
-/**
- * Last-resort suffix when the typed suffix is unavailable or also collides.
- * Uses the last 4 hex-like chars of the uuid — same shape as before for
- * backward compatibility with installations that may already display this.
- */
 function buildUuidFallbackSuffix(name: string, uuid: string): string {
     const tag = uuid.replace(/-/g, '').slice(-4);
     const tail = `${SUFFIX_SEPARATOR}${tag}`;
@@ -124,42 +130,84 @@ function buildUuidFallbackSuffix(name: string, uuid: string): string {
     return `${head}${tail}`;
 }
 
+interface SlotOwner {
+    uuid: string;
+    deviceType: string | undefined;
+    sanitizedBase: string;
+}
+
 /**
- * Tracks sanitised names per registry instance so that two devices whose
- * names normalise to the same string receive distinct, human-readable suffixes
- * based on their Lares4 device type.
+ * Tracks sanitised names per registry instance.
+ *
+ * Collision policy:
+ *
+ *  1. First arrival wins by default.
+ *  2. EXCEPT when a later device has *strictly higher type priority*: it
+ *     displaces the incumbent, takes the clean name itself, and the displaced
+ *     uuid is queued as a "pending rename" (see `consumePendingRenames`) so
+ *     the caller can refresh that accessory's metadata.
+ *  3. Same-priority collisions: incumbent keeps the clean name, newcomer
+ *     receives a typed suffix (` - Tapp.`, ` - Sens.`, ...). If the name
+ *     already mentions its own type, fall back to a uuid-derived 4-char tag.
  */
 export class MatterNameRegistry {
-    private readonly nameToUuid = new Map<string, string>();
+    private readonly slotOwners = new Map<string, SlotOwner>();
+    private readonly uuidToName = new Map<string, string>();
+    private readonly pendingRenames = new Map<string, string>();
+
+    resolve(uuid: string, sanitized: string, deviceType?: string): string {
+        const existingSlot = this.slotOwners.get(sanitized);
+
+        // No collision (or same uuid revisiting): take the clean name.
+        if (!existingSlot || existingSlot.uuid === uuid) {
+            return this.assign(uuid, sanitized, sanitized, deviceType);
+        }
+
+        // Collision with strictly higher priority → displace the incumbent.
+        if (priorityOf(deviceType) > priorityOf(existingSlot.deviceType)) {
+            const displacedName = this.suffixFor(existingSlot.uuid, existingSlot.sanitizedBase, existingSlot.deviceType);
+            this.uuidToName.set(existingSlot.uuid, displacedName);
+            this.pendingRenames.set(existingSlot.uuid, displacedName);
+            return this.assign(uuid, sanitized, sanitized, deviceType);
+        }
+
+        // Otherwise: the incumbent keeps the slot; we pick a suffix for the newcomer.
+        const candidate = this.suffixFor(uuid, sanitized, deviceType);
+        return this.assign(uuid, sanitized, candidate, deviceType);
+    }
 
     /**
-     * Return `sanitized` if it has not been used yet (or was used by the same
-     * uuid). Otherwise append a typed suffix (' - Sensore', ' - Tapparella',
-     * ...). If the typed suffix is unavailable or already taken, fall back to
-     * the legacy uuid-derived 4-char suffix.
-     *
-     * `deviceType` is the Lares4 device.type (zone, cover, light, ...). It is
-     * optional for backward compatibility with callers that pre-date the typed
-     * suffix; in that case the uuid fallback is used immediately on collision.
+     * Returns and clears the set of (uuid → newName) pairs that have been
+     * displaced since the last call. Callers should refresh the matter
+     * accessory metadata for each entry so the controller sees the new name.
      */
-    resolve(uuid: string, sanitized: string, deviceType?: string): string {
-        const existing = this.nameToUuid.get(sanitized);
-        if (!existing || existing === uuid) {
-            this.nameToUuid.set(sanitized, uuid);
-            return sanitized;
-        }
+    consumePendingRenames(): Map<string, string> {
+        const out = new Map(this.pendingRenames);
+        this.pendingRenames.clear();
+        return out;
+    }
 
-        const typed = buildTypedSuffix(sanitized, deviceType);
+    private assign(uuid: string, sanitizedBase: string, finalName: string, deviceType: string | undefined): string {
+        // Free the previous slot owned by this uuid, if any (re-mapping path).
+        const previous = this.uuidToName.get(uuid);
+        if (previous && previous !== finalName) {
+            const owner = this.slotOwners.get(previous);
+            if (owner && owner.uuid === uuid) this.slotOwners.delete(previous);
+        }
+        this.slotOwners.set(finalName, { uuid, deviceType, sanitizedBase });
+        this.uuidToName.set(uuid, finalName);
+        // If a pending rename was queued for this uuid and we're now resolving
+        // again, the caller is about to consume the up-to-date name directly.
+        this.pendingRenames.delete(uuid);
+        return finalName;
+    }
+
+    private suffixFor(uuid: string, base: string, deviceType: string | undefined): string {
+        const typed = buildTypedSuffix(base, deviceType);
         if (typed) {
-            const typedExisting = this.nameToUuid.get(typed);
-            if (!typedExisting || typedExisting === uuid) {
-                this.nameToUuid.set(typed, uuid);
-                return typed;
-            }
+            const existing = this.slotOwners.get(typed);
+            if (!existing || existing.uuid === uuid) return typed;
         }
-
-        const fallback = buildUuidFallbackSuffix(sanitized, uuid);
-        this.nameToUuid.set(fallback, uuid);
-        return fallback;
+        return buildUuidFallbackSuffix(base, uuid);
     }
 }

--- a/test/matter-name-sanitizer.test.js
+++ b/test/matter-name-sanitizer.test.js
@@ -14,10 +14,6 @@ test('sanitizeMatterAccessoryName: trims trailing space', () => {
     assert.equal(sanitizeMatterAccessoryName('Balcone Sala '), 'Balcone Sala');
 });
 
-test('sanitizeMatterAccessoryName: trims leading space', () => {
-    assert.equal(sanitizeMatterAccessoryName('  Sala'), 'Sala');
-});
-
 test('sanitizeMatterAccessoryName: replaces + with " e "', () => {
     assert.equal(
         sanitizeMatterAccessoryName('Inserisci Finestre+Tapparelle'),
@@ -29,182 +25,193 @@ test('sanitizeMatterAccessoryName: removes parentheses but keeps content', () =>
     assert.equal(sanitizeMatterAccessoryName('Apri Mattina (estate)'), 'Apri Mattina estate');
 });
 
-test('sanitizeMatterAccessoryName: removes square brackets but keeps content', () => {
-    assert.equal(sanitizeMatterAccessoryName('Zona [piano terra]'), 'Zona piano terra');
+test('sanitizeMatterAccessoryName: preserves typographic apostrophe', () => {
+    assert.equal(sanitizeMatterAccessoryName('Chiudi l’ingresso'), 'Chiudi l’ingresso');
 });
 
-test('sanitizeMatterAccessoryName: preserves typographic apostrophe (HomeKit-allowed)', () => {
-    const name = 'Chiudi l’ingresso';
-    assert.equal(sanitizeMatterAccessoryName(name), 'Chiudi l’ingresso');
-});
-
-test('sanitizeMatterAccessoryName: preserves ASCII apostrophe (HomeKit-allowed)', () => {
+test('sanitizeMatterAccessoryName: preserves ASCII apostrophe', () => {
     assert.equal(sanitizeMatterAccessoryName("Chiudi l'ingresso"), "Chiudi l'ingresso");
 });
 
-test('sanitizeMatterAccessoryName: collapses multiple spaces', () => {
-    assert.equal(sanitizeMatterAccessoryName('Balcone   Sala'), 'Balcone Sala');
-});
-
-test('sanitizeMatterAccessoryName: replaces slash with space (not in HomeKit allowlist)', () => {
-    assert.equal(sanitizeMatterAccessoryName('Luce/Presa'), 'Luce Presa');
-});
-
-test('sanitizeMatterAccessoryName: strips underscore (not in HomeKit allowlist)', () => {
+test('sanitizeMatterAccessoryName: strips underscore', () => {
     assert.equal(sanitizeMatterAccessoryName('Zona_Notte'), 'Zona Notte');
-});
-
-test('sanitizeMatterAccessoryName: strips colon, semicolon, pipe', () => {
-    assert.equal(sanitizeMatterAccessoryName('Zona: Notte; piano | terra'), 'Zona Notte piano terra');
-});
-
-test('sanitizeMatterAccessoryName: preserves period, comma, hyphen', () => {
-    assert.equal(sanitizeMatterAccessoryName('Term. Sala - Temp., 2'), 'Term. Sala - Temp., 2');
-});
-
-test('sanitizeMatterAccessoryName: handles empty string → fallback', () => {
-    assert.equal(sanitizeMatterAccessoryName('', 'Fallback'), 'Fallback');
-});
-
-test('sanitizeMatterAccessoryName: handles whitespace-only string → fallback', () => {
-    assert.equal(sanitizeMatterAccessoryName('   ', 'Fallback'), 'Fallback');
-});
-
-test('sanitizeMatterAccessoryName: uses default fallback "Device" when none supplied', () => {
-    assert.equal(sanitizeMatterAccessoryName(''), 'Device');
-});
-
-test('sanitizeMatterAccessoryName: truncates names longer than 32 chars (Matter nodeLabel limit)', () => {
-    const long = 'A'.repeat(70);
-    const result = sanitizeMatterAccessoryName(long);
-    assert.equal(result.length, 32);
-});
-
-test('sanitizeMatterAccessoryName: real-world failing scenario "Inserisci Tapparelle+Volumetrici" stays <= 32', () => {
-    const result = sanitizeMatterAccessoryName('Inserisci Tapparelle+Volumetrici');
-    assert.ok(result.length <= 32, `length ${result.length} > 32: "${result}"`);
-});
-
-test('sanitizeMatterAccessoryName: "Inserisci Finestre+Volumetrici" stays <= 32', () => {
-    const result = sanitizeMatterAccessoryName('Inserisci Finestre+Volumetrici');
-    assert.ok(result.length <= 32, `length ${result.length} > 32: "${result}"`);
 });
 
 test('sanitizeMatterAccessoryName: preserves accented Italian letters', () => {
     assert.equal(sanitizeMatterAccessoryName('Caffè è qui'), 'Caffè è qui');
 });
 
+test('sanitizeMatterAccessoryName: truncates names longer than 32 chars', () => {
+    const long = 'A'.repeat(70);
+    assert.equal(sanitizeMatterAccessoryName(long).length, 32);
+});
+
+test('sanitizeMatterAccessoryName: real-world "Inserisci Tapparelle+Volumetrici" stays <= 32', () => {
+    const result = sanitizeMatterAccessoryName('Inserisci Tapparelle+Volumetrici');
+    assert.ok(result.length <= 32, `length ${result.length}: "${result}"`);
+});
+
 test('sanitizeMatterAccessoryName: result satisfies HomeKit checkName regex', () => {
-    // Mirror the HAP-NodeJS rule:
-    //   ^[\p{L}\p{N}][\p{L}\p{N}’ '.,-]*[\p{L}\p{N}’]$
     const homekit = /^[\p{L}\p{N}][\p{L}\p{N}’ '.,\-]*[\p{L}\p{N}’]$/u;
     const samples = [
-        'Balcone Sala',
-        'Chiudi l’ingresso',
-        'Apri Mattina estate',
-        'Term. Sala - Temp.',
-        'Inserisci Finestre e Tapparelle',
-        'Caffè',
+        'Balcone Sala', 'Chiudi l’ingresso', 'Apri Mattina estate',
+        'Term. Sala - Temp.', 'Inserisci Finestre e Tapparelle', 'Caffè',
     ];
     for (const s of samples) {
         const sanitized = sanitizeMatterAccessoryName(s);
-        assert.ok(homekit.test(sanitized), `HomeKit checkName rejected "${sanitized}" (from "${s}")`);
+        assert.ok(homekit.test(sanitized), `HAP rejected "${sanitized}" (from "${s}")`);
     }
 });
 
-test('sanitizeMatterAccessoryName: strips trailing punctuation so name ends with letter/digit/apostrophe', () => {
-    // hyphen is allowed in middle but NOT at the end per HomeKit rule
-    assert.equal(sanitizeMatterAccessoryName('Sala -'), 'Sala');
-    assert.equal(sanitizeMatterAccessoryName('Sala.'), 'Sala');
+test('sanitizeMatterAccessoryName: empty string → fallback', () => {
+    assert.equal(sanitizeMatterAccessoryName('', 'Fallback'), 'Fallback');
+    assert.equal(sanitizeMatterAccessoryName(''), 'Device');
 });
 
 // ---------------------------------------------------------------------------
-// MatterNameRegistry — typed-suffix collision policy
+// MatterNameRegistry — typed-suffix collision policy with priority
 // ---------------------------------------------------------------------------
 
-test('MatterNameRegistry: returns sanitized name when no collision', () => {
-    const registry = new MatterNameRegistry();
-    assert.equal(registry.resolve('cover_1', 'Balcone Sala', 'cover'), 'Balcone Sala');
+test('MatterNameRegistry: returns clean name when no collision', () => {
+    const reg = new MatterNameRegistry();
+    assert.equal(reg.resolve('cover_1', 'Balcone Sala', 'cover'), 'Balcone Sala');
 });
 
-test('MatterNameRegistry: same uuid can resolve to same name twice', () => {
-    const registry = new MatterNameRegistry();
-    assert.equal(registry.resolve('cover_1', 'Sala', 'cover'), 'Sala');
-    assert.equal(registry.resolve('cover_1', 'Sala', 'cover'), 'Sala');
+test('MatterNameRegistry: same uuid revisiting gets the same clean name', () => {
+    const reg = new MatterNameRegistry();
+    assert.equal(reg.resolve('cover_1', 'Sala', 'cover'), 'Sala');
+    assert.equal(reg.resolve('cover_1', 'Sala', 'cover'), 'Sala');
 });
 
-test('MatterNameRegistry: collision between cover and zone uses italian typed suffix', () => {
-    const registry = new MatterNameRegistry();
-    const first = registry.resolve('cover_1', 'Finestra Cucina', 'cover');
-    const second = registry.resolve('zone_19', 'Finestra Cucina', 'zone');
-    assert.equal(first, 'Finestra Cucina');
-    assert.equal(second, 'Finestra Cucina - Sensore');
+test('MatterNameRegistry: zone arrives before cover → cover displaces zone (priority)', () => {
+    const reg = new MatterNameRegistry();
+    const z = reg.resolve('zone_19', 'Finestra Cucina', 'zone');
+    assert.equal(z, 'Finestra Cucina', 'first arrival takes the slot');
+
+    const c = reg.resolve('cover_1', 'Finestra Cucina', 'cover');
+    assert.equal(c, 'Finestra Cucina', 'higher-priority cover displaces the zone and keeps the clean name');
+
+    const pending = reg.consumePendingRenames();
+    assert.equal(pending.size, 1);
+    assert.equal(pending.get('zone_19'), 'Finestra Cucina - Sens.', 'displaced zone gets typed abbreviation');
 });
 
-test('MatterNameRegistry: collision uses the second device\'s own type, not the first one\'s', () => {
-    const registry = new MatterNameRegistry();
-    const first = registry.resolve('cover_27', 'Tapparella Studio', 'cover');
-    const second = registry.resolve('zone_27', 'Tapparella Studio', 'zone');
-    assert.equal(first, 'Tapparella Studio');
-    // zone's own type is "Sensore". "Tapparella Studio" doesn't contain "Sensore",
-    // so the typed suffix applies even though the name mentions the *other*
-    // device's type. Goal: each accessory tags itself with what it is, not what
-    // its sibling is.
-    assert.equal(second, 'Tapparella Studio - Sensore');
+test('MatterNameRegistry: cover arrives before zone → zone gets the suffix immediately', () => {
+    const reg = new MatterNameRegistry();
+    const c = reg.resolve('cover_1', 'Finestra Cucina', 'cover');
+    assert.equal(c, 'Finestra Cucina');
+
+    const z = reg.resolve('zone_19', 'Finestra Cucina', 'zone');
+    assert.equal(z, 'Finestra Cucina - Sens.');
+
+    assert.equal(reg.consumePendingRenames().size, 0, 'no displacement when newcomer is lower priority');
 });
 
-test('MatterNameRegistry: anti-redundancy — skip suffix when name already mentions the OWN type', () => {
-    const registry = new MatterNameRegistry();
-    // Two covers (hypothetical) that sanitise to the same string both containing
-    // "Tapparella". The collision suffix " - Tapparella" would be redundant, so
-    // the second one falls back to the uuid-derived suffix.
-    const first = registry.resolve('cover_10', 'Tapparella Studio', 'cover');
-    const second = registry.resolve('cover_27', 'Tapparella Studio', 'cover');
-    assert.equal(first, 'Tapparella Studio');
-    assert.notEqual(second, 'Tapparella Studio - Tapparella');
-    assert.ok(second.endsWith('r_27'), `expected uuid fallback in "${second}"`);
+test('MatterNameRegistry: typed abbreviations match the agreed table', () => {
+    const reg = new MatterNameRegistry();
+    reg.resolve('cover_a', 'Casa', 'cover');
+    assert.equal(reg.resolve('zone_a', 'Casa', 'zone'), 'Casa - Sens.');
+
+    const reg2 = new MatterNameRegistry();
+    reg2.resolve('light_a', 'Casa', 'light');
+    assert.equal(reg2.resolve('zone_b', 'Casa', 'zone'), 'Casa - Sens.');
+
+    const reg3 = new MatterNameRegistry();
+    reg3.resolve('cover_a', 'Test', 'cover');
+    assert.equal(reg3.resolve('light_a', 'Test', 'light'), 'Test - Luce', 'same-priority: typed suffix on second');
+
+    const reg4 = new MatterNameRegistry();
+    reg4.resolve('cover_a', 'Test', 'cover');
+    assert.equal(reg4.resolve('thermostat_a', 'Test', 'thermostat'), 'Test - Term.');
+
+    const reg5 = new MatterNameRegistry();
+    reg5.resolve('cover_a', 'Test', 'cover');
+    assert.equal(reg5.resolve('gate_a', 'Test', 'gate'), 'Test - Cancello');
 });
 
-test('MatterNameRegistry: unknown device type falls back to uuid suffix immediately', () => {
-    const registry = new MatterNameRegistry();
-    registry.resolve('uuid-aaaa', 'Sala', 'cover');
-    const second = registry.resolve('uuid-bbbb', 'Sala', 'mysterious');
-    assert.ok(second.endsWith('bbbb'), `expected uuid fallback for unknown type in "${second}"`);
+test('MatterNameRegistry: anti-redundancy — skip suffix when name already mentions own type', () => {
+    const reg = new MatterNameRegistry();
+    reg.resolve('cover_10', 'Tapparella Studio', 'cover');
+    const c2 = reg.resolve('cover_27', 'Tapparella Studio', 'cover');
+    // Same priority + name already says "Tapparella" → fallback uuid suffix
+    assert.notEqual(c2, 'Tapparella Studio - Tapp.');
+    assert.ok(c2.endsWith('r_27'), `uuid fallback expected, got "${c2}"`);
 });
 
-test('MatterNameRegistry: deviceType omitted (legacy caller) falls back to uuid suffix on collision', () => {
-    const registry = new MatterNameRegistry();
-    registry.resolve('uuid-aaaa', 'Sala');
-    const second = registry.resolve('uuid-bbbb', 'Sala');
-    assert.ok(second.endsWith('bbbb'));
+test('MatterNameRegistry: long name + suffix fits 32 chars with abbreviation', () => {
+    const reg = new MatterNameRegistry();
+    // "Finestra Bagno Matrimoniale" (27) + " - Sens." (8) = 35 → head gets truncated.
+    reg.resolve('cover_7', 'Finestra Bagno Matrimoniale', 'cover');
+    const z = reg.resolve('zone_25', 'Finestra Bagno Matrimoniale', 'zone');
+    assert.ok(z.length <= 32, `length ${z.length}: "${z}"`);
+    assert.ok(z.endsWith(' - Sens.'), `expected suffix tail in "${z}"`);
 });
 
-test('MatterNameRegistry: typed suffix candidate respects 32-char cap by truncating name part', () => {
-    const registry = new MatterNameRegistry();
-    const longName = 'X'.repeat(28); // 28 + " - Sensore" (10) = 38 > 32
-    registry.resolve('cover_a', longName, 'cover');
-    const second = registry.resolve('zone_b', longName, 'zone');
-    assert.ok(second.length <= 32, `length ${second.length} > 32: "${second}"`);
-    assert.ok(second.endsWith(' - Sensore'), `expected typed suffix tail in "${second}"`);
+test('MatterNameRegistry: unknown deviceType falls back to uuid suffix on collision', () => {
+    const reg = new MatterNameRegistry();
+    reg.resolve('cover_a', 'Sala', 'cover');
+    const x = reg.resolve('uuid-bbbb', 'Sala', 'mysterious');
+    assert.ok(x.endsWith('bbbb'), `got "${x}"`);
 });
 
-test('MatterNameRegistry: real-world Finestra Bagno cover + zone collision', () => {
-    const registry = new MatterNameRegistry();
-    const cover = registry.resolve('cover_5', 'Finestra Bagno', 'cover');
-    const zone = registry.resolve('zone_22', 'Finestra Bagno', 'zone');
-    assert.equal(cover, 'Finestra Bagno');
-    assert.equal(zone, 'Finestra Bagno - Sensore');
+test('MatterNameRegistry: deviceType omitted (legacy) → uuid fallback on collision', () => {
+    const reg = new MatterNameRegistry();
+    reg.resolve('uuid-aaaa', 'Sala');
+    const x = reg.resolve('uuid-bbbb', 'Sala');
+    assert.ok(x.endsWith('bbbb'));
 });
 
-test('MatterNameRegistry: thermostat colliding with another thermostat falls back to uuid suffix', () => {
-    const registry = new MatterNameRegistry();
-    // Two thermostats with the same sanitised name (artificial, but covers the
-    // "typed suffix also collides" code path).
-    const first = registry.resolve('thermostat_18', 'Sala', 'thermostat');
-    const second = registry.resolve('thermostat_34', 'Sala', 'thermostat');
-    assert.equal(first, 'Sala');
-    // "Sala - Termostato" would also collide if both insisted; with single
-    // collision the typed suffix wins. Verify the second one uses the typed suffix
-    // (no third item is colliding here).
-    assert.equal(second, 'Sala - Termostato');
+test('MatterNameRegistry: real-world Lares4 cover-vs-zone collisions (full ordering)', () => {
+    const reg = new MatterNameRegistry();
+    // Lares4 emits ZONES first, MULTI_TYPES (cover) second.
+    const zones = [
+        ['zone_18', 'Finestra Studio'],
+        ['zone_19', 'Finestra Cucina'],
+        ['zone_22', 'Finestra Bagno'],
+        ['zone_24', 'Finestra Matrimoniale'],
+        ['zone_25', 'Finestra Bagno Matrimoniale'],
+        ['zone_26', 'Finestra Cameretta'],
+    ];
+    for (const [uuid, name] of zones) {
+        assert.equal(reg.resolve(uuid, name, 'zone'), name, `zone ${uuid} should take clean name first`);
+    }
+    const covers = [
+        ['cover_1', 'Finestra Cucina'],
+        ['cover_4', 'Finestra Studio'],
+        ['cover_5', 'Finestra Bagno'],
+        ['cover_6', 'Finestra Matrimoniale'],
+        ['cover_7', 'Finestra Bagno Matrimoniale'],
+        ['cover_8', 'Finestra Cameretta'],
+    ];
+    for (const [uuid, name] of covers) {
+        assert.equal(reg.resolve(uuid, name, 'cover'), name, `cover ${uuid} displaces and takes clean name`);
+    }
+    const renames = reg.consumePendingRenames();
+    assert.equal(renames.size, 6);
+    assert.equal(renames.get('zone_19'), 'Finestra Cucina - Sens.');
+    assert.equal(renames.get('zone_22'), 'Finestra Bagno - Sens.');
+    assert.equal(renames.get('zone_24'), 'Finestra Matrimoniale - Sens.');
+    // Truncated: "Finestra Bagno Matrimoniale" (27) + " - Sens." (8) = 35 → head shortened.
+    const tappBagnoMatri = renames.get('zone_25');
+    assert.ok(tappBagnoMatri.endsWith(' - Sens.'));
+    assert.ok(tappBagnoMatri.length <= 32);
+});
+
+test('MatterNameRegistry: consumePendingRenames returns and clears (idempotent)', () => {
+    const reg = new MatterNameRegistry();
+    reg.resolve('zone_1', 'Sala', 'zone');
+    reg.resolve('cover_1', 'Sala', 'cover');
+    assert.equal(reg.consumePendingRenames().size, 1);
+    assert.equal(reg.consumePendingRenames().size, 0, 'second consume is empty');
+});
+
+test('MatterNameRegistry: re-resolving the displaced uuid clears its pending entry', () => {
+    const reg = new MatterNameRegistry();
+    reg.resolve('zone_1', 'Sala', 'zone');
+    reg.resolve('cover_1', 'Sala', 'cover'); // displaces zone_1
+    // Caller refreshes zone_1 by re-mapping. After this resolve, the pending
+    // entry must be consumed (the name is now up-to-date in-band).
+    const renamed = reg.resolve('zone_1', 'Sala', 'zone');
+    assert.equal(renamed, 'Sala - Sens.');
+    assert.equal(reg.consumePendingRenames().size, 0);
 });


### PR DESCRIPTION
## Summary

Follow-up to 2.1.4-rc.2 driven by the production boot log. Two compound issues:

**1. Wrong device wins the clean name.** Lares4 emits \`ZONES\` before \`MULTI_TYPES\`, so the contact-sensor *zone* took the clean label and the controllable *cover* ended up suffixed. Real example from the log: \`Finestra Cucina - Tapparella\` (cover) vs \`Finestra Cucina\` (zone). The user-facing accessory (the cover) should be the one without the tag.

**2. Mid-word truncation.** Suffix \`- Tapparella\` (10 chars) overflowed names like \`Finestra Matrimoniale\` → \`Finestra Matrimonia - Tapparella\` (Matrimoniale chopped at 32-char nodeLabel limit).

## Fix

- **Priority-based collision policy** in \`MatterNameRegistry\`: cover/light/thermostat/gate/scenario (priority 10) displace zone/sensor (priority 1). When a higher-priority device arrives second, it takes the clean name and the previous owner is queued as a *pending rename* (\`consumePendingRenames\`). \`MatterAccessoryRegistry\` drains the queue after each successful register and calls \`refreshAccessoryMetadata\` on the displaced accessories.
- **Abbreviated suffix table**: \`zone/sensor → ' - Sens.'\`, \`cover → ' - Tapp.'\`, \`light → ' - Luce'\`, \`thermostat → ' - Term.'\`, \`scenario → ' - Scenario'\`, \`gate → ' - Cancello'\`. Short enough that real-world Lares4 names fit without head truncation.
- **Root-based anti-redundancy**: \`Tapparella Studio\` no longer gets \`- Tapp.\` on same-priority collision (matches \`\\bTapp\` so \`Tapparella\` is recognised as already mentioning the type).

## Expected post-deploy log

| Before (rc.2) | After (rc.3) |
|---|---|
| Cover \`Finestra Cucina -> \"Finestra Cucina - Tapparella\"\` | Cover \`Finestra Cucina\` (clean) |
| Zone \`Finestra Cucina\` (clean) | Zone \`Finestra Cucina -> \"Finestra Cucina - Sens.\"\` |
| Cover \`Finestra Matrimonia - Tapparella\` (truncated) | Cover \`Finestra Matrimoniale\` (clean) |
| Cover \`Finestra Bagno Matr - Tapparella\` (truncated) | Cover \`Finestra Bagno Matrimoniale\` (clean) |

UUIDs unchanged. Custom names set in Apple Home / Alexa survive.

## Test plan

- [x] \`npm run verify\`: **155/155 pass**, including a regression test that replays the real Lares4 ordering (6 zones then 6 covers) and asserts each cover keeps the clean name + each zone is queued for rename with the abbreviated suffix.
- [x] Anti-redundancy test (\`Tapparella Studio\` + \`Tapparella Studio\` same-priority collision falls back to uuid suffix, not \` - Tapp.\`).
- [x] Long-name truncation test stays within 32 chars while preserving the suffix tail.
- [ ] Manual on the smarthome container after \`2.1.4-rc.3\` publish.

## Release

Tag \`v2.1.4-rc.3\` after merge → \`release-publish.yml\` → npm \`rc\` dist-tag.