### PR TITLE
Harden prune discipline, telemetry scrubbing, and name collision detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — Telemetry: value-level PII scrubbing (Sentry)
+
+- `beforeSend` now scrubs **values**, not just keys: IPv4 addresses (with optional port) and `ws(s)://`/`http(s)://` URLs are redacted from `event.message`, every `exception.values[].value`, breadcrumb messages/data and string values in `extra`/`contexts`. Network errors like `connect ECONNREFUSED <panel-ip>:443` no longer leak the panel address — the README promise ("no IP is ever transmitted") now holds for error texts too.
+- The exact config-derived secrets (`ip`, `pin`, `sender`) are passed to `initTelemetry` and redacted verbatim (case-insensitive) from every outgoing text field — this also covers hostname-based setups (`getaddrinfo ENOTFOUND lares.local`).
+- `server_name` (the machine hostname Sentry attaches by default) is removed from every event.
+- Key-based scrubbing extended to compound keys (`ipAddress`, `hostname`, `deviceName`, `roomName`).
+- Docblock fixed: `initTelemetry` now documents the actual opt-out semantics (default enabled, `telemetry: false` disables) instead of claiming opt-in.
+
+### Fixed — Matter prune discipline effective across restarts
+
+- **Persisted missing-cycle counters** (`klares4-matter-prune.json`): on a stable connection the plugin runs exactly one discovery+prune cycle per boot, so the in-memory 3-consecutive-cycles counter could never cross the threshold across restarts — a type disabled via `matterExposure` (or a genuinely stale cached endpoint) survived forever. Counters now persist and are cleared as soon as the device reappears; the discipline is unchanged (still 3 consecutive cycles), it just counts for real across boots.
+- **Realtime state keeps a device alive**: `updateAccessoryState` now marks the device as seen in the current discovery cycle, so an accessory that keeps pushing status updates can never become a stale-prune candidate because of a partial discovery — closing a potential churn loop (unregister at threshold → re-register on the next status update).
+- **HAP-side prune safety net**: `pruneStaleAccessories` (HAP bridge) skips the pass entirely when the sync discovered *zero* devices — a failed/partial sync can no longer wipe every cached HomeKit accessory (rooms/automations) in one shot.
+
+### Fixed — Matter name registry: case-insensitive slots
+
+- The incremental `MatterNameRegistry` (fallback path for devices not in the persisted map) matched name slots **case-sensitively**, while the authoritative batch map is case-insensitive — a case-different duplicate ("finestra studio" vs seeded "Finestra Studio") could briefly hold two equal voice names until the next finalize. Slot keys are now lowercased, aligning both paths.
+- Typed-suffix roots are regex-escaped in `nameAlreadyMentions` (robustness for future suffix entries containing metacharacters).
+
+### Fixed — Name hygiene: DOMUS sensors
+
+- The DOMUS sensor triple (`… - Temperatura` / `… - Umidita` / `… - Luminosita`) built its base name from the raw `DES`, bypassing the rc.6 parse-time normalisation — trailing/multiple spaces could re-enter HAP/MQTT names via `BUS_HAS`. Now normalised like every other parser.
+
+### Changed — Boot I/O
+
+- `klares4-devices.json` was rewritten once per discovered device (N racing async writes per sync, ~109 on the reference install). Writes are now debounced (1 s after the last discovery event): one write per sync, startup summary timing unchanged.
+
+### Tests
+
+- **225/225 passing (10 new):** telemetry value-scrubbing (IP/URL redaction, config-derived secrets, `server_name`, compound keys), case-insensitive registry slots, status-updates-keep-alive prune guard, persisted prune counters across three simulated boots (including counter reset on reappearance), HAP empty-sync prune guard.
+
 ## [2.1.4-rc.6] - 2026-07-05
 
 ### Fixed — Deterministic voice-command names on any Matter controller

--- a/src/platform/accessory-registry.ts
+++ b/src/platform/accessory-registry.ts
@@ -111,6 +111,16 @@ export class AccessoryRegistry {
     }
 
     public pruneStaleAccessories(): void {
+        // Safety net: a sync that discovered NOTHING is a failed/partial sync
+        // (WS glitch, panel busy), not a panel with zero devices. Removing every
+        // cached accessory here would wipe HomeKit rooms/automations for the
+        // whole bridge — skip and let the next complete sync prune for real.
+        if (this.options.activeDiscoveredUUIDs.size === 0 && this.options.accessories.size > 0) {
+            this.options.log.warn(
+                'Skipping accessory prune: discovery returned no devices (partial or failed sync)',
+            );
+            return;
+        }
         for (const [uuid, accessory] of this.options.accessories) {
             if (!this.options.activeDiscoveredUUIDs.has(uuid)) {
                 this.removeAccessory(accessory);

--- a/src/platform/device-list-service.ts
+++ b/src/platform/device-list-service.ts
@@ -16,35 +16,36 @@ interface DeviceListServiceOptions {
     lifecycleService: PlatformLifecycleService;
 }
 
+const DEVICES_FILE_WRITE_DEBOUNCE_MS = 1000;
+
 export class DeviceListService {
     private readonly devicesFilePath: string;
+    private writeTimer?: NodeJS.Timeout;
+    private pendingList?: DevicesList;
 
     constructor(private readonly options: DeviceListServiceOptions) {
         this.devicesFilePath = path.join(options.storagePath, 'klares4-devices.json');
     }
 
+    /**
+     * Called once per discovered device during a sync — the list is rebuilt
+     * cheaply every time, but the file write (and the summary) are debounced
+     * so a boot with N devices produces one write, not N racing writes.
+     */
     public saveDevicesList(discoveredDevices: Iterable<KseniaDevice>): void {
         try {
-            const devicesList = this.buildDevicesList(discoveredDevices);
-            const serializedDevices = JSON.stringify(devicesList, null, 2);
+            this.pendingList = this.buildDevicesList(discoveredDevices);
 
-            void fs.promises
-                .writeFile(this.devicesFilePath, serializedDevices, 'utf8')
-                .then((): void => {
-                    const count =
-                        devicesList.outputs.length +
-                        devicesList.zones.length +
-                        devicesList.sensors.length +
-                        devicesList.scenarios.length;
-                    this.options.log.debug(`Devices list saved: ${count} devices`);
-                })
-                .catch((error: unknown): void => {
-                    this.options.log.error(
-                        'Error saving devices list:',
-                        error instanceof Error ? error.message : String(error),
-                    );
-                });
+            if (this.writeTimer) {
+                clearTimeout(this.writeTimer);
+            }
+            this.writeTimer = setTimeout((): void => {
+                this.writeTimer = undefined;
+                this.flushPendingWrite();
+            }, DEVICES_FILE_WRITE_DEBOUNCE_MS);
+            this.writeTimer.unref?.();
 
+            const devicesList = this.pendingList;
             const summaryDelay = this.options.config.devicesSummaryDelay ?? 2000;
             this.options.lifecycleService.scheduleSummary((): void => {
                 this.printDevicesSummary(devicesList);
@@ -55,6 +56,32 @@ export class DeviceListService {
                 error instanceof Error ? error.message : String(error),
             );
         }
+    }
+
+    private flushPendingWrite(): void {
+        const devicesList = this.pendingList;
+        if (!devicesList) {
+            return;
+        }
+        this.pendingList = undefined;
+        const serializedDevices = JSON.stringify(devicesList, null, 2);
+
+        void fs.promises
+            .writeFile(this.devicesFilePath, serializedDevices, 'utf8')
+            .then((): void => {
+                const count =
+                    devicesList.outputs.length +
+                    devicesList.zones.length +
+                    devicesList.sensors.length +
+                    devicesList.scenarios.length;
+                this.options.log.debug(`Devices list saved: ${count} devices`);
+            })
+            .catch((error: unknown): void => {
+                this.options.log.error(
+                    'Error saving devices list:',
+                    error instanceof Error ? error.message : String(error),
+                );
+            });
     }
 
     private buildDevicesList(discoveredDevices: Iterable<KseniaDevice>): DevicesList {

--- a/src/platform/index.ts
+++ b/src/platform/index.ts
@@ -102,7 +102,11 @@ export class Lares4Platform implements DynamicPlatformPlugin {
             return;
         }
 
-        initTelemetry(this.config.telemetry, PLUGIN_VERSION_RAW);
+        initTelemetry(this.config.telemetry, PLUGIN_VERSION_RAW, [
+            this.config.ip,
+            this.config.pin,
+            this.config.sender,
+        ].filter((v): v is string => typeof v === 'string'));
 
         this.log.debug('Platform initialization completed:', this.config.name);
 

--- a/src/platform/matter-accessory-registry.ts
+++ b/src/platform/matter-accessory-registry.ts
@@ -66,7 +66,7 @@ export class MatterAccessoryRegistry {
         this.momentaryAutoOffMs = deps.momentaryAutoOffMs;
         this.isDeviceExposed = deps.isDeviceExposed;
         this.fallbackStore = new MatterFallbackStore(deps.storagePath, deps.log);
-        this.pruneTracker = new MatterPruneTracker(this.log);
+        this.pruneTracker = new MatterPruneTracker(this.log, deps.storagePath);
         this.nameService = new MatterNameService(deps.storagePath, deps.log);
         for (const uuid of this.fallbackStore.load()) this.thermostatFallbackUUIDs.add(uuid);
 
@@ -135,6 +135,9 @@ export class MatterAccessoryRegistry {
     public async updateAccessoryState(device: KseniaDevice): Promise<void> {
         if (!this.api.matter) return;
         if (this.isDeviceExposed && !this.isDeviceExposed(device)) return;
+        // A device pushing realtime state is alive by definition: mark it seen
+        // so a partial discovery can't count it towards the stale-prune threshold.
+        this.activeDiscoveredUUIDs.add(device.id);
         const existing = this.registrations.get(device.id);
         if (!existing) {
             await this.registerAccessory(device);

--- a/src/platform/matter-name-sanitizer.ts
+++ b/src/platform/matter-name-sanitizer.ts
@@ -81,7 +81,7 @@ function nameAlreadyMentions(name: string, suffix: string): boolean {
     // recognised as already mentioning "Tapp.", and "Termostato Sala" as
     // already mentioning "Term.". Avoids redundant " - Tapp." / " - Term."
     // tags on names that already describe their own type.
-    const root = suffix.replace(/\.$/, '');
+    const root = suffix.replace(/\.$/, '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     const pattern = new RegExp(`\\b${root}`, 'iu');
     return pattern.test(name);
 }
@@ -142,9 +142,18 @@ interface SlotOwner {
  * yet (first boot ever, devices newly added on the panel).
  */
 export class MatterNameRegistry {
+    /**
+     * Keyed by *lowercased* display name: voice assistants resolve utterances
+     * case-insensitively, so the collision namespace must be case-insensitive
+     * too — same rule as the batch map (`computeMatterNameMap`).
+     */
     private readonly slotOwners = new Map<string, SlotOwner>();
     private readonly uuidToName = new Map<string, string>();
     private readonly pendingRenames = new Map<string, string>();
+
+    private slotKey(name: string): string {
+        return name.toLowerCase();
+    }
 
     /**
      * Pre-assign a uuid → name mapping loaded from the persisted name-map.
@@ -153,7 +162,7 @@ export class MatterNameRegistry {
      * devices see it and pick a suffix (or displace it by priority).
      */
     seed(uuid: string, finalName: string, sanitizedBase: string, deviceType?: string): void {
-        this.slotOwners.set(finalName, { uuid, deviceType, sanitizedBase });
+        this.slotOwners.set(this.slotKey(finalName), { uuid, deviceType, sanitizedBase });
         this.uuidToName.set(uuid, finalName);
     }
 
@@ -163,7 +172,7 @@ export class MatterNameRegistry {
     }
 
     resolve(uuid: string, sanitized: string, deviceType?: string): string {
-        const existingSlot = this.slotOwners.get(sanitized);
+        const existingSlot = this.slotOwners.get(this.slotKey(sanitized));
 
         // No collision (or same uuid revisiting): take the clean name.
         if (!existingSlot || existingSlot.uuid === uuid) {
@@ -183,7 +192,7 @@ export class MatterNameRegistry {
             // Register the displaced uuid's new slot so a *third* colliding
             // device (same-priority tie, e.g. three identically-named sensors)
             // sees it as taken and doesn't independently pick the same suffix.
-            this.slotOwners.set(displacedName, {
+            this.slotOwners.set(this.slotKey(displacedName), {
                 uuid: existingSlot.uuid,
                 deviceType: existingSlot.deviceType,
                 sanitizedBase: existingSlot.sanitizedBase,
@@ -212,11 +221,11 @@ export class MatterNameRegistry {
     private assign(uuid: string, sanitizedBase: string, finalName: string, deviceType: string | undefined): string {
         // Free the previous slot owned by this uuid, if any (re-mapping path).
         const previous = this.uuidToName.get(uuid);
-        if (previous && previous !== finalName) {
-            const owner = this.slotOwners.get(previous);
-            if (owner && owner.uuid === uuid) this.slotOwners.delete(previous);
+        if (previous && this.slotKey(previous) !== this.slotKey(finalName)) {
+            const owner = this.slotOwners.get(this.slotKey(previous));
+            if (owner && owner.uuid === uuid) this.slotOwners.delete(this.slotKey(previous));
         }
-        this.slotOwners.set(finalName, { uuid, deviceType, sanitizedBase });
+        this.slotOwners.set(this.slotKey(finalName), { uuid, deviceType, sanitizedBase });
         this.uuidToName.set(uuid, finalName);
         // If a pending rename was queued for this uuid and we're now resolving
         // again, the caller is about to consume the up-to-date name directly.
@@ -227,7 +236,7 @@ export class MatterNameRegistry {
     private suffixFor(uuid: string, base: string, deviceType: string | undefined): string {
         const typed = buildTypedSuffix(base, deviceType);
         if (typed) {
-            const existing = this.slotOwners.get(typed);
+            const existing = this.slotOwners.get(this.slotKey(typed));
             if (!existing || existing.uuid === uuid) return typed;
         }
         return buildUuidFallbackSuffix(base, uuid);

--- a/src/platform/matter-prune-tracker.ts
+++ b/src/platform/matter-prune-tracker.ts
@@ -1,9 +1,18 @@
+import * as fs from 'fs';
+import * as path from 'path';
 import type { API, Logger, MatterAccessory } from 'homebridge';
 import { PLUGIN_NAME, PLATFORM_NAME } from '../settings';
 import type { KseniaDevice } from '../types';
 import type { MatterRegistration } from './matter-registration-recovery';
 import type { MatterFallbackStore } from './matter-fallback-store';
 import type { MatterThermostatEchoTracker } from './matter-thermostat-echo-tracker';
+
+const COUNTER_STORE_FILENAME = 'klares4-matter-prune.json';
+
+interface CounterStoreShape {
+    version: 1;
+    missing: Record<string, number>;
+}
 
 /**
  * Minimum number of consecutive discovery cycles an accessory must be absent
@@ -51,8 +60,53 @@ export class MatterPruneTracker {
     private readonly missingCycleCounts = new Map<string, number>();
     private cycleNumber = 0;
     private stats: MatterCycleStats = emptyStats();
+    private readonly counterFilePath?: string;
+    private countersDirty = false;
 
-    constructor(private readonly log: Logger) {}
+    /**
+     * When `storagePath` is provided the missing-cycle counters persist across
+     * restarts (`klares4-matter-prune.json`). Without persistence a stable
+     * setup runs exactly ONE prune cycle per boot, the in-memory counter
+     * restarts from zero every time and the 3-consecutive-cycles threshold is
+     * never crossed — so a genuinely stale endpoint (device removed from the
+     * panel, type disabled via `matterExposure`) would survive forever.
+     */
+    constructor(private readonly log: Logger, storagePath?: string) {
+        if (storagePath) {
+            this.counterFilePath = path.join(storagePath, COUNTER_STORE_FILENAME);
+            this.loadCounters();
+        }
+    }
+
+    private loadCounters(): void {
+        if (!this.counterFilePath) return;
+        try {
+            if (!fs.existsSync(this.counterFilePath)) return;
+            const parsed = JSON.parse(fs.readFileSync(this.counterFilePath, 'utf8')) as Partial<CounterStoreShape>;
+            if (!parsed.missing || typeof parsed.missing !== 'object') return;
+            for (const [uuid, count] of Object.entries(parsed.missing)) {
+                if (typeof count === 'number' && Number.isInteger(count) && count > 0) {
+                    this.missingCycleCounts.set(uuid, count);
+                }
+            }
+        } catch (err) {
+            this.log.warn(`[Matter] Could not load prune-counter store (${this.counterFilePath}): ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+
+    private saveCountersIfDirty(): void {
+        if (!this.counterFilePath || !this.countersDirty) return;
+        this.countersDirty = false;
+        try {
+            const payload: CounterStoreShape = {
+                version: 1,
+                missing: Object.fromEntries([...this.missingCycleCounts.entries()].sort(([a], [b]) => (a < b ? -1 : 1))),
+            };
+            fs.writeFileSync(this.counterFilePath, JSON.stringify(payload, null, 2), 'utf8');
+        } catch (err) {
+            this.log.warn(`[Matter] Could not write prune-counter store (${this.counterFilePath}): ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
 
     /** Marks the start of a new discovery cycle and resets per-cycle counters. */
     startCycle(): void {
@@ -83,6 +137,7 @@ export class MatterPruneTracker {
     /** Device seen in the current cycle: clears its missing-cycle counter, if any. */
     recordSeen(uuid: string, displayName: string): void {
         if (this.missingCycleCounts.delete(uuid)) {
+            this.countersDirty = true;
             this.log.debug(`[Matter] Missing-cycle counter reset for ${displayName} (${uuid}) — device reappeared`);
         }
     }
@@ -94,6 +149,7 @@ export class MatterPruneTracker {
     recordMissing(uuid: string, displayName: string): boolean {
         const missedCycles = (this.missingCycleCounts.get(uuid) ?? 0) + 1;
         this.missingCycleCounts.set(uuid, missedCycles);
+        this.countersDirty = true;
 
         if (missedCycles < MATTER_PRUNE_STALE_THRESHOLD_CYCLES) {
             this.log.info(
@@ -112,7 +168,9 @@ export class MatterPruneTracker {
 
     /** Clears the missing-cycle counter after a real unregister. */
     clearMissing(uuid: string): void {
-        this.missingCycleCounts.delete(uuid);
+        if (this.missingCycleCounts.delete(uuid)) {
+            this.countersDirty = true;
+        }
     }
 
     logCycleSummary(discovered: number, registered: number, missingCandidates: number, pruneSkipped: number, unregistered: number): void {
@@ -160,6 +218,8 @@ export class MatterPruneTracker {
                 await this.pruneCandidate(uuid, device.name, deps, counters);
             }
         }
+
+        this.saveCountersIfDirty();
 
         this.logCycleSummary(
             deps.activeDiscoveredUUIDs.size,

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -2,51 +2,90 @@ import * as Sentry from '@sentry/node';
 
 const SENTRY_DSN = 'https://6a99b131b91b591e7a98ea136e8c4837@o4511676680699904.ingest.de.sentry.io/4511676714647632';
 
-const SENSITIVE_KEYS = /^(pin|password|token|secret|ip|host|url|sender|config|payload|name|room|device)$/i;
+const SENSITIVE_KEYS = /^(pin|password|token|secret|ip|ipaddress|host|hostname|url|sender|config|payload|name|devicename|room|roomname|device)$/i;
+
+// Network errors embed the panel address in the *message* itself, e.g.
+// "connect ECONNREFUSED 192.168.1.10:443" or "getaddrinfo ENOTFOUND lares.local".
+// Key-based scrubbing can't catch those, so every outgoing text field is also
+// passed through these value-level patterns (URLs first: they may contain IPs).
+const URL_PATTERN = /\b(?:wss?|https?):\/\/[^\s"')]+/gi;
+const IPV4_PATTERN = /\b\d{1,3}(?:\.\d{1,3}){3}(?::\d{1,5})?\b/g;
 
 let initialized = false;
+/** Exact config-derived strings (panel IP/host, PIN, sender) scrubbed from every text field. */
+let sensitiveValues: string[] = [];
+
+function escapeRegExp(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Scrub URLs, IPv4 addresses and configured sensitive strings from free text. */
+function scrubText(text: string): string {
+    let out = text.replace(URL_PATTERN, '[url]').replace(IPV4_PATTERN, '[ip]');
+    for (const value of sensitiveValues) {
+        out = out.replace(new RegExp(escapeRegExp(value), 'gi'), '[redacted]');
+    }
+    return out;
+}
+
+function scrubRecordValues(record: Record<string, unknown>): void {
+    for (const key of Object.keys(record)) {
+        if (SENSITIVE_KEYS.test(key)) {
+            delete record[key];
+            continue;
+        }
+        const value = record[key];
+        if (typeof value === 'string') {
+            record[key] = scrubText(value);
+        }
+    }
+}
 
 /**
  * Strips sensitive fields from a Sentry event before it leaves the process.
  * Exported for testing.
  */
 export function sanitizeEventData(event: Sentry.ErrorEvent): Sentry.ErrorEvent | null {
-    // Never send user or request data
+    // Never send user, request or machine-identifying data
     delete event.user;
     delete event.request;
+    delete event.server_name;
 
-    // Scrub sensitive keys from extra
-    if (event.extra) {
-        for (const key of Object.keys(event.extra)) {
-            if (SENSITIVE_KEYS.test(key)) {
-                delete event.extra[key];
+    // Scrub error messages: network errors carry the panel address in the text
+    if (typeof event.message === 'string') {
+        event.message = scrubText(event.message);
+    }
+    if (event.exception?.values) {
+        for (const ex of event.exception.values) {
+            if (typeof ex.value === 'string') {
+                ex.value = scrubText(ex.value);
             }
         }
     }
 
-    // Scrub sensitive keys from contexts
+    // Scrub sensitive keys and string values from extra
+    if (event.extra) {
+        scrubRecordValues(event.extra);
+    }
+
+    // Scrub sensitive keys and string values from contexts
     if (event.contexts) {
         for (const ctxName of Object.keys(event.contexts)) {
             const ctx = event.contexts[ctxName];
             if (ctx && typeof ctx === 'object') {
-                for (const key of Object.keys(ctx)) {
-                    if (SENSITIVE_KEYS.test(key)) {
-                        delete ctx[key];
-                    }
-                }
+                scrubRecordValues(ctx);
             }
         }
     }
 
-    // Scrub breadcrumb data
+    // Scrub breadcrumb messages and data
     if (event.breadcrumbs) {
         for (const bc of event.breadcrumbs) {
+            if (typeof bc.message === 'string') {
+                bc.message = scrubText(bc.message);
+            }
             if (bc.data) {
-                for (const key of Object.keys(bc.data)) {
-                    if (SENSITIVE_KEYS.test(key)) {
-                        delete bc.data[key];
-                    }
-                }
+                scrubRecordValues(bc.data);
             }
         }
     }
@@ -55,10 +94,20 @@ export function sanitizeEventData(event: Sentry.ErrorEvent): Sentry.ErrorEvent |
 }
 
 /**
- * Initializes Sentry only when `config.telemetry === true`.
+ * Initializes Sentry unless `config.telemetry === false` (opt-out, default
+ * enabled — see README "Telemetry" and config.schema.json).
  * Safe to call multiple times — subsequent calls are no-ops.
+ *
+ * @param sensitive Config-derived strings (panel IP/host, PIN, sender) that
+ *   must never appear in an outgoing event, scrubbed by `sanitizeEventData`.
  */
-export function initTelemetry(telemetryEnabled: boolean | undefined, version: string): void {
+export function initTelemetry(telemetryEnabled: boolean | undefined, version: string, sensitive?: string[]): void {
+    // Record the scrub list even when disabled: sanitizeEventData must be safe
+    // to exercise (tests) and a later re-init keeps the same guarantees.
+    if (sensitive) {
+        sensitiveValues = sensitive.filter((v): v is string => typeof v === 'string' && v.length >= 3);
+    }
+
     if (telemetryEnabled === false || initialized) {
         return;
     }
@@ -119,4 +168,5 @@ export function closeTelemetry(): void {
  */
 export function _resetForTesting(): void {
     initialized = false;
+    sensitiveValues = [];
 }

--- a/src/websocket-client/message-service.ts
+++ b/src/websocket-client/message-service.ts
@@ -11,6 +11,7 @@ import type {
 } from '../types';
 import type { CommandService } from './command-service';
 import { determineOutputType, isIgnoredScenarioCategory, parseOutputData, parseScenarioData, parseZoneData } from './device-parsers';
+import { normalizeDeviceName } from '../websocket/device-state-projector';
 import { normalizeDomusSensorId } from './domus-thermostat-mapper';
 import { refreshDomusThermostatMapping } from './domus-thermostat-mapping-runtime';
 import { ThermostatStatusUpdater } from './thermostat-status-updater';
@@ -144,7 +145,7 @@ export class MessageService {
                 payload.BUS_HAS.forEach((sensor: KseniaBusHaData): void => {
                     const normalizedSensorId = normalizeDomusSensorId(sensor.ID);
                     this.deps.state.domusSensors.set(normalizedSensorId, { ...sensor, ID: normalizedSensorId });
-                    const baseName = sensor.DES || `Sensor ${normalizedSensorId}`;
+                    const baseName = normalizeDeviceName(sensor.DES) || `Sensor ${normalizedSensorId}`;
 
                     const tempDevice = {
                         id: `sensor_temp_${normalizedSensorId}`,

--- a/test/matter-accessory-registry.test.js
+++ b/test/matter-accessory-registry.test.js
@@ -720,3 +720,107 @@ test('matterExposure: cached-only endpoints of a disabled type (config changed a
     assert.deepEqual(unregistered, ['zone_9'], 'cached-only disabled-type endpoint removed on the third cycle');
     assert.ok(registered.every((r) => r.UUID !== 'zone_9'), 'the zombie was never re-registered');
 });
+
+// ---------------------------------------------------------------------------
+// Conservative prune hardening (2.1.4 review)
+// ---------------------------------------------------------------------------
+
+test('prune: realtime status updates keep a device alive even when discovery misses it', async () => {
+    const { api, unregistered } = makeApi();
+    const registry = new MatterAccessoryRegistry({ api, log: silentLog(), getWsClient: () => undefined, storagePath: tmpStorage() });
+    registry.startDiscoveryCycle();
+    await registry.addOrUpdateAccessory(lightDevice('light_a'));
+    await registry.addOrUpdateAccessory(lightDevice('light_b'));
+    await delay(200);
+
+    // Four cycles where discovery misses light_b, but the device keeps
+    // pushing realtime state — it is alive and must never be pruned.
+    for (let i = 0; i < 4; i++) {
+        registry.startDiscoveryCycle();
+        await registry.addOrUpdateAccessory(lightDevice('light_a'));
+        await registry.updateAccessoryState({ ...lightDevice('light_b'), status: { on: false, dimmable: false } });
+        await registry.pruneStaleAccessories();
+    }
+
+    assert.deepEqual(unregistered, [], 'a device pushing state updates must never be pruned');
+    assert.equal(registry.getStatus('light_b'), 'registered');
+});
+
+test('prune: missing-cycle counters persist across boots (stable setups run one cycle per boot)', async () => {
+    const storagePath = tmpStorage();
+    const zombie = zoneDevice('zone_9', 'Porta Garage');
+    let lastBoot;
+
+    // Production reality on a stable connection: ONE discovery + prune cycle
+    // per boot. Each boot is a fresh registry instance; without persisted
+    // counters the 3-cycle threshold could never be crossed across restarts.
+    for (let boot = 1; boot <= 3; boot++) {
+        const bootCtx = makeApi();
+        const registry = new MatterAccessoryRegistry({
+            api: bootCtx.api,
+            log: silentLog(),
+            getWsClient: () => undefined,
+            storagePath,
+            isDeviceExposed: (device) => device.type !== 'zone',
+        });
+        registry.configureCachedAccessory({ UUID: 'zone_9', displayName: 'Porta Garage', context: { device: zombie } });
+        registry.startDiscoveryCycle();
+        await registry.addOrUpdateAccessory(lightDevice('light_1'));
+        await delay(200);
+        await registry.pruneStaleAccessories();
+        lastBoot = bootCtx;
+        if (boot < 3) {
+            assert.deepEqual(bootCtx.unregistered, [], `boot ${boot}: below threshold, cached zombie kept`);
+        }
+    }
+
+    assert.deepEqual(lastBoot.unregistered, ['zone_9'], 'third boot crosses the persisted threshold and unregisters');
+});
+
+test('prune: persisted counter is cleared when the device reappears on a later boot', async () => {
+    const storagePath = tmpStorage();
+    const zone = zoneDevice('zone_5', 'Finestra Bagno');
+    let zonesExposed = false;
+    const exposure = (device) => device.type !== 'zone' || zonesExposed;
+
+    // Boot 1+2: zone disabled → two persisted misses.
+    for (let boot = 1; boot <= 2; boot++) {
+        const bootCtx = makeApi();
+        const registry = new MatterAccessoryRegistry({
+            api: bootCtx.api, log: silentLog(), getWsClient: () => undefined, storagePath, isDeviceExposed: exposure,
+        });
+        registry.configureCachedAccessory({ UUID: 'zone_5', displayName: 'Finestra Bagno', context: { device: zone } });
+        registry.startDiscoveryCycle();
+        await registry.addOrUpdateAccessory(lightDevice('light_1'));
+        await delay(200);
+        await registry.pruneStaleAccessories();
+        assert.deepEqual(bootCtx.unregistered, [], `boot ${boot}: below threshold`);
+    }
+
+    // Boot 3: user re-enables zones → device is discovered again, counter resets.
+    zonesExposed = true;
+    const boot3 = makeApi();
+    const registry3 = new MatterAccessoryRegistry({
+        api: boot3.api, log: silentLog(), getWsClient: () => undefined, storagePath, isDeviceExposed: exposure,
+    });
+    registry3.configureCachedAccessory({ UUID: 'zone_5', displayName: 'Finestra Bagno', context: { device: zone } });
+    registry3.startDiscoveryCycle();
+    await registry3.addOrUpdateAccessory(zone);
+    await registry3.addOrUpdateAccessory(lightDevice('light_1'));
+    await delay(200);
+    await registry3.pruneStaleAccessories();
+    assert.deepEqual(boot3.unregistered, [], 'reappeared device must not be unregistered');
+
+    // Boot 4: disabled again → must start counting from 1, not resume from 2.
+    zonesExposed = false;
+    const boot4 = makeApi();
+    const registry4 = new MatterAccessoryRegistry({
+        api: boot4.api, log: silentLog(), getWsClient: () => undefined, storagePath, isDeviceExposed: exposure,
+    });
+    registry4.configureCachedAccessory({ UUID: 'zone_5', displayName: 'Finestra Bagno', context: { device: zone } });
+    registry4.startDiscoveryCycle();
+    await registry4.addOrUpdateAccessory(lightDevice('light_1'));
+    await delay(200);
+    await registry4.pruneStaleAccessories();
+    assert.deepEqual(boot4.unregistered, [], 'counter must have restarted after the reappearance');
+});

--- a/test/matter-name-sanitizer.test.js
+++ b/test/matter-name-sanitizer.test.js
@@ -286,3 +286,15 @@ test('MatterNameRegistry: steady-state re-resolution produces no further pending
     reg.resolve('cover_5', 'Finestra Bagno', 'cover');
     assert.equal(reg.consumePendingRenames().size, 0, 'steady-state re-resolution must not produce further renames');
 });
+
+test('MatterNameRegistry: collision detection is case-insensitive (voice namespace)', () => {
+    const reg = new MatterNameRegistry();
+    reg.resolve('cover_1', 'Finestra Studio', 'cover');
+    const z = reg.resolve('zone_2', 'finestra studio', 'zone');
+    assert.equal(z, 'finestra studio - Sens.', 'case-different duplicate must be suffixed like the batch map');
+
+    const reg2 = new MatterNameRegistry();
+    reg2.seed('light_5', 'Studio', 'Studio', 'light');
+    const other = reg2.resolve('zone_9', 'STUDIO', 'zone');
+    assert.notEqual(other.toLowerCase(), 'studio', 'seeded slot must be honoured case-insensitively');
+});

--- a/test/platform-accessory-registry.test.js
+++ b/test/platform-accessory-registry.test.js
@@ -36,6 +36,7 @@ function createRegistryHarness() {
 
   const log = {
     info: () => undefined,
+    warn: () => undefined,
   };
 
   const registry = new AccessoryRegistry({
@@ -97,5 +98,24 @@ test('AccessoryRegistry prunes stale accessories', () => {
 
   assert.equal(accessories.has('uuid-light_1'), true);
   assert.equal(accessories.has('uuid-light_2'), false);
+  assert.deepEqual(unregistered, ['uuid-light_2']);
+});
+
+test('AccessoryRegistry skips prune entirely when discovery returned no devices', () => {
+  const { registry, accessories, handlers, active, unregistered } = createRegistryHarness();
+  accessories.set('uuid-light_1', new FakeAccessory('Luce', 'uuid-light_1'));
+  accessories.set('uuid-light_2', new FakeAccessory('Luce2', 'uuid-light_2'));
+  handlers.set('uuid-light_1', { id: 'handler1' });
+  handlers.set('uuid-light_2', { id: 'handler2' });
+  // active set intentionally empty: failed/partial sync
+
+  registry.pruneStaleAccessories();
+
+  assert.equal(accessories.size, 2, 'no accessory may be removed on an empty sync');
+  assert.deepEqual(unregistered, []);
+
+  // Once discovery works again, prune behaves normally.
+  active.add('uuid-light_1');
+  registry.pruneStaleAccessories();
   assert.deepEqual(unregistered, ['uuid-light_2']);
 });

--- a/test/telemetry.test.js
+++ b/test/telemetry.test.js
@@ -153,3 +153,60 @@ test('closeTelemetry is safe to call when not initialized', () => {
   _resetForTesting();
   closeTelemetry(); // should not throw
 });
+
+// ---------------------------------------------------------------------------
+// value-level scrubbing (panel IP/host must never leave the process)
+// ---------------------------------------------------------------------------
+
+test('sanitizeEventData scrubs IPs and URLs from error messages', () => {
+  _resetForTesting();
+  const event = {
+    message: 'Connecting to wss://192.168.1.10:443/KseniaWsock failed',
+    exception: { values: [
+      { type: 'Error', value: 'connect ECONNREFUSED 192.168.1.10:443' },
+      { type: 'Error', value: 'plain error without addresses' },
+    ] },
+  };
+  const result = sanitizeEventData(event);
+  assert.ok(!result.message.includes('192.168.1.10'), `message still leaks the IP: ${result.message}`);
+  assert.equal(result.exception.values[0].value, 'connect ECONNREFUSED [ip]');
+  assert.equal(result.exception.values[1].value, 'plain error without addresses');
+});
+
+test('sanitizeEventData scrubs configured sensitive values (panel host, PIN)', () => {
+  _resetForTesting();
+  initTelemetry(false, '1.0.0', ['lares.local', '123456']);
+  const event = {
+    exception: { values: [{ type: 'Error', value: 'getaddrinfo ENOTFOUND lares.local (pin 123456)' }] },
+  };
+  const result = sanitizeEventData(event);
+  assert.ok(!result.exception.values[0].value.includes('lares.local'));
+  assert.ok(!result.exception.values[0].value.includes('123456'));
+  _resetForTesting();
+});
+
+test('sanitizeEventData removes server_name (machine hostname)', () => {
+  const event = { server_name: 'raspberrypi.lan', message: 'x' };
+  const result = sanitizeEventData(event);
+  assert.equal(result.server_name, undefined);
+});
+
+test('sanitizeEventData scrubs string values in extra and breadcrumb messages', () => {
+  _resetForTesting();
+  const event = {
+    extra: { detail: 'ws error at 10.0.0.7:80' },
+    breadcrumbs: [{ message: 'opened wss://10.0.0.7/KseniaWsock' }],
+  };
+  const result = sanitizeEventData(event);
+  assert.equal(result.extra.detail, 'ws error at [ip]');
+  assert.ok(!result.breadcrumbs[0].message.includes('10.0.0.7'));
+});
+
+test('sanitizeEventData strips compound sensitive keys (ipAddress, hostname, deviceName)', () => {
+  const event = { extra: { ipAddress: '10.0.0.9', hostname: 'lares.lan', deviceName: 'Camera', step: 'x' } };
+  const result = sanitizeEventData(event);
+  assert.equal(result.extra.ipAddress, undefined);
+  assert.equal(result.extra.hostname, undefined);
+  assert.equal(result.extra.deviceName, undefined);
+  assert.equal(result.extra.step, 'x');
+});


### PR DESCRIPTION
## Summary

This PR addresses three stability and privacy concerns: (1) the Matter prune discipline now persists across restarts so stale devices are actually removed on stable setups, (2) telemetry scrubbing is hardened to redact IP addresses and URLs from error messages and configured secrets from all text fields, and (3) name collision detection is made case-insensitive to match voice assistant semantics.

## Key Changes

### Matter Prune Discipline (Persistence & Realtime Updates)
- **Persisted missing-cycle counters** (`klares4-matter-prune.json`): on a stable connection the plugin runs one discovery+prune cycle per boot, so the in-memory 3-cycle threshold could never cross restarts. Counters now persist in `MatterPruneTracker` and are cleared when a device reappears.
- **Realtime state keeps devices alive**: `updateAccessoryState` now marks devices as seen in the current cycle, preventing churn from partial discovery misses.
- **HAP-side safety net**: `AccessoryRegistry.pruneStaleAccessories()` skips the pass entirely when discovery returned zero devices (failed/partial sync), preventing accidental wipeout of all cached HomeKit accessories.
- Added comprehensive test coverage for counter persistence across boots and reappearance scenarios.

### Telemetry: Value-Level PII Scrubbing
- Extended `sanitizeEventData` to scrub **values**, not just keys: IPv4 addresses (with optional port) and `ws(s)://`/`http(s)://` URLs are redacted from error messages, exception values, breadcrumb messages, and string values in `extra`/`contexts`.
- Config-derived secrets (`ip`, `pin`, `sender`) are now passed to `initTelemetry` and redacted verbatim (case-insensitive) from all outgoing text fields.
- `server_name` (machine hostname) is removed from every event.
- Key-based scrubbing extended to compound keys (`ipAddress`, `hostname`, `deviceName`, `roomName`).
- Fixed docblock: `initTelemetry` now documents actual opt-out semantics (default enabled, `telemetry: false` disables).
- Added test coverage for URL/IP scrubbing, configured secret redaction, and compound key removal.

### Name Registry: Case-Insensitive Collision Detection
- `MatterNameRegistry` now uses lowercased slot keys to match the case-insensitive batch map (`computeMatterNameMap`), preventing case-different duplicates from briefly holding two equal voice names.
- `nameAlreadyMentions` now regex-escapes the suffix root for robustness with future metacharacter-containing entries.
- Added test verifying case-insensitive collision detection aligns with voice assistant semantics.

### Device List Service: Write Debouncing
- `DeviceListService.saveDevicesList()` now debounces file writes (1s window) so a boot with N devices produces one write instead of N racing writes.

## Implementation Details

- `MatterPruneTracker` loads/saves counters on construction and after each cycle, with dirty-flag optimization to avoid unnecessary writes.
- Telemetry scrubbing uses regex patterns for URLs and IPv4 addresses, plus a dynamic list of configured secrets that are escaped and applied case-insensitively.
- Name registry slot keys are lowercased at all access points (`seed`, `resolve`) to ensure consistent collision detection.
- HAP prune safety check is minimal: skip if `activeDiscoveredUUIDs.size === 0 && accessories.size > 0`.